### PR TITLE
Idea for issue #17 about ambiguous error

### DIFF
--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -241,9 +241,9 @@ fetch_tbl <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE)
     }
   }
   tbl <- if (length(col_names) > 0) {
-    readr::read_csv(r, col_types = col_types)
+    readr::read_csv(I(r), col_types = col_types)
   } else {
-    readr::read_csv(r)
+    readr::read_csv(I(r))
   }
 
 


### PR DESCRIPTION
One way to look at the error described in #17  is that it occurs because `read_csv` interprets its argument as a filename instead of literal data. Simply wrapping the argument of read_csv within `I` can prevent that, as described in the docs [here](https://readr.tidyverse.org/reference/read_delim.html).

With this change the test case of a call that produces a null result
 
 ```r
 y <- covidcast( 
       data_source = "bad-source", 
       signals = "bad-signal", 
       geo_type = "state",  
       time_type = "day", 
       time_value = epirange(20200601, 20221201),
       geo_values = "ca,fl")
 ```

produces a
 
```r
> y %>% fetch_tbl()
# A tibble: 0 × 15
# … with 15 variables: X1 <chr>, X2 <chr>, X3 <chr>, X4 <chr>, X5 <chr>, X6 <chr>, X7 <chr>, X8 <chr>, X9 <chr>, X10 <chr>,
#   X11 <chr>, X12 <chr>, X13 <chr>, X14 <chr>, X15 <chr>
# ℹ Use `colnames()` to see all variable names
Warning message:
The following named parsers don't match the column names: source, signal, geo_type, geo_value, time_type, time_value, issue, lag, value, stderr, sample_size, direction, missing_value, missing_stderr, missing_sample_size
 ```
At least the situation is clearer.

