### PR TITLE
Apply rename and slightly adjust format of User-Agent

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,3 +1,3 @@
 version <- "1.0.0"
-http_headers <- httr::add_headers("User-Agent" = paste0("delphi_epidata", version))
+http_headers <- httr::add_headers("User-Agent" = paste0("epidatr/", version))
 global_base_url <- "https://delphi.cmu.edu/epidata/"


### PR DESCRIPTION
- Rename `delphi_epidata` -> `epidatr`
- Add slash between package name and version, to match epidatpy's format for
  User-Agent (and the convention for specifying versions in User-Agent)