### PR TITLE
change from devtools to remotes for install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Install
 
-Install latest version using [`devtools`](https://cran.r-project.org/package=devtools) package
+Install latest version using [`remotes`](https://cran.r-project.org/package=remotes) package
 
 ```R
-devtools::install_github("cmu-delphi/epidatr")
+remotes::install_github("cmu-delphi/epidatr")
 ```
 
 Note (2022-08-02): the package that this installs is being renamed from

--- a/man/covid_hosp_facility_lookup.Rd
+++ b/man/covid_hosp_facility_lookup.Rd
@@ -30,7 +30,8 @@ an instance of epidata_call
 API docs: https://cmu-delphi.github.io/delphi-epidata/api/covid_hosp_facility_lookup.html
 }
 \examples{
-\donttest{ # can take a few minutes; donttesting while backend performance is being improved
+\donttest{
+# can take a few minutes; donttesting while backend performance is being improved
 call <- covid_hosp_facility_lookup(state = "fl")
 fetch_csv(call)
 }

--- a/man/fluview_clinical.Rd
+++ b/man/fluview_clinical.Rd
@@ -22,7 +22,8 @@ an instance of epidata_call
 API docs: https://cmu-delphi.github.io/delphi-epidata/api/fluview_clinical.html
 }
 \examples{
-\donttest{ # can take a couple minutes; donttesting while cmu-delphi/delphi-epidata#48 is unresolved
+\donttest{
+# can take a couple minutes; donttesting while cmu-delphi/delphi-epidata#48 is unresolved
 call <- fluview_clinical(regions = "nat", epiweeks = epirange(201201, 202001))
 fetch_classic(call)
 }

--- a/vignettes/covidcast.Rmd
+++ b/vignettes/covidcast.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(echo = TRUE)
 # Delphi Epidata R API Client
 
 ```{r libraries}
-# devtools::install_github("cmu-delphi/epidatr")
+# remotes::install_github("cmu-delphi/epidatr")
 library("epidatr")
 library("magrittr")
 ```

--- a/vignettes/epidatr.Rmd
+++ b/vignettes/epidatr.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(echo = TRUE)
 # Delphi Epidata R API Client
 
 ```{r libraries}
-# devtools::install_github("cmu-delphi/epidatr")
+# remotes::install_github("cmu-delphi/epidatr")
 library("epidatr")
 library("magrittr")
 ```


### PR DESCRIPTION
it's better to use remotes since it has fewer dependencies than devtools