### PR TITLE
update base url to reference `api.covidcast.cmu.edu/epidata`

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,3 +1,3 @@
 version <- "1.0.0"
 http_headers <- httr::add_headers("User-Agent" = paste0("epidatr/", version), "Accept-Encoding" = "gzip")
-global_base_url <- "https://delphi.cmu.edu/epidata/"
+global_base_url <- "https://api.covidcast.cmu.edu/epidata/"


### PR DESCRIPTION
see https://github.com/cmu-delphi/delphi-epidata/pull/1164