### PR TITLE
update base url to `api.delphi.cmu.edu`

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,3 +1,3 @@
 version <- "1.0.0"
 http_headers <- httr::add_headers("User-Agent" = paste0("epidatr/", version), "Accept-Encoding" = "gzip")
-global_base_url <- "https://api.covidcast.cmu.edu/epidata/"
+global_base_url <- "https://api.delphi.cmu.edu/epidata/"


### PR DESCRIPTION
follow-up to #103

approvals are very welcome, but this should not be merged until we have a new cert installed for api.delphi.cmu.edu. (PR is in draft status to prevent accidental merging.)