### PR TITLE
Internals docs

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -1,5 +1,6 @@
 #' Allows character vectors
 #' @importFrom checkmate assert_character assert_integerish
+#' @keywords internal
 assert_character_param <- function(name, value, len = NULL, required = TRUE) {
   null.ok <- !required
   assert_integerish(len, null.ok = TRUE, .var.name = "len")
@@ -8,6 +9,7 @@ assert_character_param <- function(name, value, len = NULL, required = TRUE) {
 
 #' Allows integer-like vectors
 #' @importFrom checkmate assert_integerish
+#' @keywords internal
 assert_integerish_param <- function(name, value, len = NULL, required = TRUE) {
   null.ok <- !required
   assert_integerish(len, null.ok = TRUE, .var.name = "len")
@@ -16,6 +18,7 @@ assert_integerish_param <- function(name, value, len = NULL, required = TRUE) {
 
 #' Allows a vector of date_like params: date, character, or integer-like
 #' @importFrom checkmate check_date check_character check_integerish
+#' @keywords internal
 assert_date_param <- function(name, value, len = NULL, required = TRUE) {
   null.ok <- !required
   assert_integerish(len, null.ok = TRUE, .var.name = "len")

--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -35,7 +35,7 @@
 #'
 #' @return
 #' - For `create_epidata_call`: an `epidata_call` object
-#' @keywords internal
+#'
 create_epidata_call <- function(endpoint, params, meta = NULL,
                                 only_supports_classic = FALSE) {
   stopifnot(is.character(endpoint), length(endpoint) == 1)
@@ -128,7 +128,7 @@ fetch <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE) {
 }
 
 #' Fetches the data and returns a tibble
-#' @rdname epidata_call
+#' @rdname fetch_tbl
 #'
 #' @param epidata_call an instance of `epidata_call`
 #' @param fields a list of epidata fields to return, or NULL to return all
@@ -162,7 +162,7 @@ fetch_tbl <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE)
 #' Fetches the data, raises on epidata errors, and returns the results as a
 #' JSON-like list
 #'
-#' @rdname epidata_call
+#' @rdname fetch_classic
 #'
 #' @param epidata_call an instance of `epidata_call`
 #' @param fields a list of epidata fields to return, or NULL to return all
@@ -224,7 +224,7 @@ full_url <- function(epidata_call) {
 }
 
 #' Returns the full request url for the given epidata_call
-#' @rdname epidata_call
+#' @rdname request_url
 #'
 #' @param epidata_call an instance of `epidata_call`
 #' @param format_type format to return one of classic,json,csv

--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -35,7 +35,7 @@
 #'
 #' @return
 #' - For `create_epidata_call`: an `epidata_call` object
-#'
+#' @keywords internal
 create_epidata_call <- function(endpoint, params, meta = NULL,
                                 only_supports_classic = FALSE) {
   stopifnot(is.character(endpoint), length(endpoint) == 1)
@@ -142,7 +142,7 @@ fetch <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE) {
 #' @return
 #' - For `fetch_tbl`: a [`tibble::tibble`]
 #' @importFrom tibble as_tibble
-#'
+#' @keywords internal
 fetch_tbl <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE) {
   stopifnot(inherits(epidata_call, "epidata_call"))
   stopifnot(is.null(fields) || is.character(fields))
@@ -176,7 +176,7 @@ fetch_tbl <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE)
 #' @importFrom jsonlite fromJSON
 #' @return
 #' - For `fetch_classic`: a JSON-like list
-#'
+#' @keywords internal
 fetch_classic <- function(epidata_call, fields = NULL, disable_data_frame_parsing = TRUE) {
   stopifnot(inherits(epidata_call, "epidata_call"))
   stopifnot(is.null(fields) || is.character(fields))
@@ -235,6 +235,7 @@ full_url <- function(epidata_call) {
 #' @importFrom httr modify_url
 #' @return
 #' - For `request_url`: string containing the URL
+#' @keywords internal
 request_url <- function(epidata_call, format_type = "classic", fields = NULL) {
   stopifnot(inherits(epidata_call, "epidata_call"))
   url <- full_url(epidata_call)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 #' Helper function to cast values, non-list vectors, and/or EpiRanges to strings
 #'
-#' @noRd
+#' @keywords internal
 format_item <- function(value) {
   if (inherits(value, "EpiRange")) {
     paste0(toString(value$from), "-", toString(value$to))
@@ -13,7 +13,7 @@ format_item <- function(value) {
 
 #' Helper function to build a list of values and/or ranges
 #'
-#' @noRd
+#' @keywords internal
 format_list <- function(values) {
   paste(vapply(values, format_item, character(1L)), collapse = ",")
 }

--- a/man/assert_character_param.Rd
+++ b/man/assert_character_param.Rd
@@ -9,3 +9,4 @@ assert_character_param(name, value, len = NULL, required = TRUE)
 \description{
 Allows character vectors
 }
+\keyword{internal}

--- a/man/assert_date_param.Rd
+++ b/man/assert_date_param.Rd
@@ -9,3 +9,4 @@ assert_date_param(name, value, len = NULL, required = TRUE)
 \description{
 Allows a vector of date_like params: date, character, or integer-like
 }
+\keyword{internal}

--- a/man/assert_integerish_param.Rd
+++ b/man/assert_integerish_param.Rd
@@ -9,3 +9,4 @@ assert_integerish_param(name, value, len = NULL, required = TRUE)
 \description{
 Allows integer-like vectors
 }
+\keyword{internal}

--- a/man/epidata_call.Rd
+++ b/man/epidata_call.Rd
@@ -111,3 +111,4 @@ covidcast(
 ) \%>\% fetch()
 
 }
+\keyword{internal}

--- a/man/epidata_call.Rd
+++ b/man/epidata_call.Rd
@@ -4,9 +4,6 @@
 \alias{create_epidata_call}
 \alias{epidata_call}
 \alias{fetch}
-\alias{fetch_tbl}
-\alias{fetch_classic}
-\alias{request_url}
 \alias{with_base_url}
 \title{An abstraction that holds information needed to make an epidata request}
 \usage{
@@ -18,12 +15,6 @@ create_epidata_call(
 )
 
 fetch(epidata_call, fields = NULL, disable_date_parsing = FALSE)
-
-fetch_tbl(epidata_call, fields = NULL, disable_date_parsing = FALSE)
-
-fetch_classic(epidata_call, fields = NULL, disable_data_frame_parsing = TRUE)
-
-request_url(epidata_call, format_type = "classic", fields = NULL)
 
 with_base_url(epidata_call, base_url)
 }
@@ -45,12 +36,6 @@ the direction field}
 
 \item{disable_date_parsing}{disable automatic date parsing}
 
-\item{disable_data_frame_parsing}{do not automatically cast the epidata
-output to a data frame (some endpoints return a list of lists, which is not
-a data frame)}
-
-\item{format_type}{format to return one of classic,json,csv}
-
 \item{base_url}{base URL to use}
 }
 \value{
@@ -60,18 +45,6 @@ a data frame)}
 
 \itemize{
 \item For \code{fetch}: a tibble or a JSON-like list
-}
-
-\itemize{
-\item For \code{fetch_tbl}: a \code{\link[tibble:tibble]{tibble::tibble}}
-}
-
-\itemize{
-\item For \code{fetch_classic}: a JSON-like list
-}
-
-\itemize{
-\item For \code{request_url}: string containing the URL
 }
 
 \itemize{
@@ -111,4 +84,3 @@ covidcast(
 ) \%>\% fetch()
 
 }
-\keyword{internal}


### PR DESCRIPTION
closes #108 
In the process of doing this, I noticed that the [epidata_call](https://cmu-delphi.github.io/epidatr/reference/epidata_call.html) docs are in a weird state. On the [reference page](https://cmu-delphi.github.io/epidatr/reference/index.html), there's a mass of functions all together `create_epidata_call() fetch() fetch_tbl() fetch_classic() request_url() with_base_url() ` which point at that page. Several of these are internal only, and some were actually moved from external to strictly internal. The second commit in the pull request may deal with that