### PR TITLE
docs: actual example for `pvt_norostat`

### DIFF
--- a/vignettes/endpoints.Rmd
+++ b/vignettes/endpoints.Rmd
@@ -357,7 +357,7 @@ Function reference: <https://cmu-delphi.github.io/epidatr/reference/pvt_norostat
 Example call:
 
 ```{r, eval=FALSE}
-pvt_norostat(auth = Sys.getenv("SECRET_API_AUTH_NOROSTAT"), locations = "1", epiweeks = 201233) %>% fetch()
+pvt_norostat(auth = Sys.getenv("SECRET_API_AUTH_NOROSTAT"), locations = "Minnesota, Ohio, Oregon, Tennessee, and Wisconsin", epiweeks = 201233) %>% fetch()
 ```
 
 ### Quidel Covid and Influenza testing


### PR DESCRIPTION
`pvt_norostat`'s locations are a bit unusual. This gives at least one functional example. Ideally we'd also point at a full list of the locations, but as per https://github.com/cmu-delphi/delphi-epidata/issues/1209 there isn't such a public list atm