### PR TITLE
Extreme requests

### DIFF
--- a/R/covidcast.R
+++ b/R/covidcast.R
@@ -100,15 +100,16 @@ print.covidcast_data_source <- function(source, ...) {
 #' print(smoothed_cli)
 #' df <- smoothed_cli$call("nation", "us", epirange(20210405, 20210410))
 #' @param base_url optional alternative API base url
+#' @param timeout_seconds the maximum amount of time to wait for a response
 #' @importFrom httr stop_for_status content http_type
 #' @importFrom jsonlite fromJSON
 #' @importFrom xml2 read_html xml_find_all xml_text
 #' @return an instance of covidcast_epidata
 #'
 #' @export
-covidcast_epidata <- function(base_url = global_base_url) {
+covidcast_epidata <- function(base_url = global_base_url, timeout_seconds = 30) {
   url <- join_url(base_url, "covidcast/meta")
-  response <- do_request(url, list())
+  response <- do_request(url, list(), timeout_seconds)
 
   if (response$status_code != 200) {
     # 500, 429, 401 are possible

--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -122,9 +122,10 @@ fetch <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE, ret
   stopifnot(is.null(fields) || is.character(fields))
   stopifnot(is.logical(disable_date_parsing), length(disable_date_parsing) == 1)
   stopifnot(is.logical(return_empty))
+  stopifnot(is.numeric(timeout_seconds))
 
   if (epidata_call$only_supports_classic) {
-    return(fetch_classic(epidata_call, fields, return_empty, timeout_seconds))
+    return(fetch_classic(epidata_call, fields, return_empty = return_empty, timeout_seconds = timeout_seconds))
   } else {
     return(fetch_tbl(epidata_call, fields, disable_date_parsing, return_empty))
   }
@@ -153,6 +154,7 @@ fetch_tbl <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE,
   stopifnot(is.null(fields) || is.character(fields))
   stopifnot(is.logical(disable_date_parsing), length(disable_date_parsing) == 1)
   stopifnot(is.logical(return_empty))
+  stopifnot(is.numeric(timeout_seconds))
 
   if (epidata_call$only_supports_classic) {
     rlang::abort("This endpoint only supports the classic message format, due to a non-standard behavior. Use fetch_classic instead.",
@@ -161,7 +163,7 @@ fetch_tbl <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE,
     )
   }
 
-  response_content <- fetch_classic(epidata_call, fields, disable_data_frame_parsing = FALSE, return_empty = return_empty, timeout_seconds)
+  response_content <- fetch_classic(epidata_call, fields, disable_data_frame_parsing = FALSE, return_empty = return_empty, timeout_seconds = timeout_seconds)
   if (return_empty && length(response_content) == 0) {
     return(tibble())
   }
@@ -192,6 +194,7 @@ fetch_classic <- function(epidata_call, fields = NULL, disable_data_frame_parsin
   stopifnot(inherits(epidata_call, "epidata_call"))
   stopifnot(is.null(fields) || is.character(fields))
   stopifnot(is.logical(return_empty))
+  stopifnot(is.numeric(timeout_seconds))
 
   response <- request_impl(epidata_call, "classic", fields, timeout_seconds)
   response_content <- httr::content(response, as = "text", encoding = "UTF-8")

--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -127,7 +127,7 @@ fetch <- function(epidata_call, fields = NULL, disable_date_parsing = FALSE, ret
   if (epidata_call$only_supports_classic) {
     return(fetch_classic(epidata_call, fields, return_empty = return_empty, timeout_seconds = timeout_seconds))
   } else {
-    return(fetch_tbl(epidata_call, fields, disable_date_parsing, return_empty))
+    return(fetch_tbl(epidata_call, fields, disable_date_parsing, return_empty, timeout_seconds = timeout_seconds))
   }
 }
 

--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -184,22 +184,6 @@ fetch_classic <- function(epidata_call, fields = NULL, disable_data_frame_parsin
   response <- request_impl(epidata_call, "classic", fields)
   response_content <- httr::content(response, as = "text", encoding = "UTF-8")
 
-  # TODO Temporary workaround the first row of the response being a comment
-  # Remove on 2023-06-21
-  if (grepl("This request exceeded", response_content) && !epidata_call$only_supports_classic) {
-    response_content <- jsonlite::fromJSON(response_content, simplifyDataFrame = FALSE)
-    message <- response_content$epidata[[1L]]
-    cli::cli_abort(c(
-      "epidata warning, promoted to error: {message}",
-      "i" = "Either:",
-      "*" = "set the environment variable DELPHI_EPIDATA_KEY, or",
-      "*" = 'set the option "delphi.epidata.key":',
-      " " = '{.code options(delphi.epidata.key = "YOUR_KEY_OR_TEMP_KEY")}',
-      "To save your key for later sessions (and hide it from your code), you can edit your .Renviron file with:",
-      "*" = "usethis::edit_r_environ()"
-    ))
-  }
-
   response_content <- jsonlite::fromJSON(response_content, simplifyDataFrame = !disable_data_frame_parsing)
 
   # success is 1, no results is -2, truncated is 2, -1 is generic error

--- a/R/request.R
+++ b/R/request.R
@@ -21,14 +21,15 @@ join_url <- function(url, endpoint) {
 #' }
 #'
 #' @importFrom httr RETRY
-do_request <- function(url, params) {
+do_request <- function(url, params, timeout_seconds = 30) {
   # don't retry in case of certain status codes
   res <- httr::RETRY("GET",
     url = url,
     query = params,
     terminate_on = c(400, 401, 403, 405, 414, 500),
     http_headers,
-    httr::authenticate("epidata", get_auth_key())
+    httr::authenticate("epidata", get_auth_key()),
+    httr::timeout(timeout_seconds)
   )
   if (res$status_code == 414) {
     res <- httr::RETRY("POST",

--- a/man/covidcast_epidata.Rd
+++ b/man/covidcast_epidata.Rd
@@ -4,10 +4,12 @@
 \alias{covidcast_epidata}
 \title{creates the covidcast epidata helper}
 \usage{
-covidcast_epidata(base_url = global_base_url)
+covidcast_epidata(base_url = global_base_url, timeout_seconds = 30)
 }
 \arguments{
 \item{base_url}{optional alternative API base url}
+
+\item{timeout_seconds}{the maximum amount of time to wait for a response}
 }
 \value{
 an instance of covidcast_epidata

--- a/man/do_request.Rd
+++ b/man/do_request.Rd
@@ -4,7 +4,7 @@
 \alias{do_request}
 \title{performs the request}
 \usage{
-do_request(url, params)
+do_request(url, params, timeout_seconds = 30)
 }
 \description{
 You can test the authentication headers like so:

--- a/man/epidata_call.Rd
+++ b/man/epidata_call.Rd
@@ -14,7 +14,12 @@ create_epidata_call(
   only_supports_classic = FALSE
 )
 
-fetch(epidata_call, fields = NULL, disable_date_parsing = FALSE)
+fetch(
+  epidata_call,
+  fields = NULL,
+  disable_date_parsing = FALSE,
+  return_empty = FALSE
+)
 
 with_base_url(epidata_call, base_url)
 }
@@ -35,6 +40,8 @@ time_value and value fields or c("-direction") to return everything except
 the direction field}
 
 \item{disable_date_parsing}{disable automatic date parsing}
+
+\item{return_empty}{boolean that allows returning an empty tibble if there is no data.}
 
 \item{base_url}{base URL to use}
 }

--- a/man/epidata_call.Rd
+++ b/man/epidata_call.Rd
@@ -18,7 +18,8 @@ fetch(
   epidata_call,
   fields = NULL,
   disable_date_parsing = FALSE,
-  return_empty = FALSE
+  return_empty = FALSE,
+  timeout_seconds = 30
 )
 
 with_base_url(epidata_call, base_url)
@@ -41,7 +42,9 @@ the direction field}
 
 \item{disable_date_parsing}{disable automatic date parsing}
 
-\item{return_empty}{boolean that allows returning an empty tibble if there is no data.}
+\item{return_empty}{boolean that allows returning an empty tibble if there is no data}
+
+\item{timeout_seconds}{the maximum amount of time to wait for a response}
 
 \item{base_url}{base URL to use}
 }

--- a/man/request_impl.Rd
+++ b/man/request_impl.Rd
@@ -5,7 +5,7 @@
 \title{Makes a request to the API and returns the response, catching
 HTTP errors and forwarding the HTTP body in R errors}
 \usage{
-request_impl(epidata_call, format_type, fields = NULL)
+request_impl(epidata_call, format_type, fields = NULL, timeout_seconds = 30)
 }
 \description{
 Makes a request to the API and returns the response, catching

--- a/tests/testthat/test-epidatacall.R
+++ b/tests/testthat/test-epidatacall.R
@@ -81,21 +81,20 @@ test_that("fetch_tbl warns on non-success", {
     .package = "httr"
   )
   # TODO: Turn these tests back on, when the API is fully online
-  # Remove on 2023-06-21
-  # artificial_warning <- "* This is a warning with a leading asterisk and {braces} to make sure we don't have bulleting/glue bugs."
-  # debug_triplet <- readRDS(testthat::test_path("data/test-classic.rds")) %>%
-  #   jsonlite::fromJSON() %>%
-  #   `[[<-`("message", artificial_warning)
-  # local_mocked_bindings(
-  #   # see generation code above
-  #   fromJSON = function(...) debug_triplet,
-  #   .package = "jsonlite"
-  # )
+  artificial_warning <- "* This is a warning with a leading asterisk and {braces} to make sure we don't have bulleting/glue bugs."
+  debug_triplet <- readRDS(testthat::test_path("data/test-classic.rds")) %>%
+    jsonlite::fromJSON() %>%
+    `[[<-`("message", artificial_warning)
+  local_mocked_bindings(
+    # see generation code above
+    fromJSON = function(...) debug_triplet,
+    .package = "jsonlite"
+  )
 
-  # expect_warning(epidata_call %>% fetch_tbl(),
-  #   regexp = paste0("epidata warning: ", artificial_warning),
-  #   fixed = TRUE
-  # )
+  expect_warning(epidata_call %>% fetch_tbl(),
+    regexp = paste0("epidata warning: ", artificial_warning),
+    fixed = TRUE
+  )
 })
 
 test_that("classic only fetch", {

--- a/vignettes/endpoints.Rmd
+++ b/vignettes/endpoints.Rmd
@@ -141,7 +141,7 @@ Example call:
 
 ```{r}
 del <- delphi(system = "ec", epiweek = 201501) %>% fetch()
-names(del[[1L]]$forecast)
+names(del$forecast)
 ```
 
 ### FluSurv hospitalization data


### PR DESCRIPTION
Adds two parameters to several functions:
- `timeout_seconds` gives the maximum time before a connection will time out. Default is 30 seconds, which matches the value returned in the call below (can't find documentation for httr's default, since it clearly isn't using [libcurl's](https://curl.se/libcurl/c/CURLOPT_TIMEOUT.html)). Originally motivated by
  ```
  chng_outpatient <- epidatr::covidcast(
    data_source = "chng", signals = "smoothed_adj_outpatient_covid",
    geo_type = "state",
    time_type = "day",
    time_values = "*",
    geo_values = "*",
    issues = epirange("2020-11-16","2021-03-16")
  ) %>% fetch()
  ```
  which returns a timeout message, trying 3 times. A working version in this branch is
  ```
  chng_outpatient <- epidatr::covidcast(
    data_source = "chng", signals = "smoothed_adj_outpatient_covid",
    geo_type = "state",
    time_type = "day",
    time_values = "*",
    geo_values = "*",
    issues = epirange("2020-11-16","2021-03-16")
  ) %>% fetch(timeout_seconds = 2.5 * 60)
  ```
  I'm not sure there's a nice way to add a unit test for something like this however. Perhaps `httptest` has something.
- `return_empty`, which handles the case of no returned results whatsoever. Defaults to `FALSE`, which is the current value. Even if its true it throws a warning. We may want to consider making `TRUE` the default. I debated adding headers to empty columns, but it ended up being more awkward to use on the other end.
  Should be relatively easy to add tests, but I haven't yet. It does work in the pipeline that motivated it (breaking the above into months, some of which `chng` has no data).