### PR TITLE
fix: cache size integer overflow

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -163,7 +163,7 @@ set_cache <- function(cache_dir = NULL,
   } else if (cache_exists) {
     cache_environ$epidatr_cache <- cachem::cache_disk(
       dir = cache_dir,
-      max_size = as.integer(max_size * 1024^2),
+      max_size = max_size * 1024^2,
       max_age = days * 24 * 60 * 60,
       logfile = file.path(cache_dir, logfile)
     )

--- a/man/get_api_key.Rd
+++ b/man/get_api_key.Rd
@@ -52,7 +52,7 @@ Delphi Epidata API Registration Form.
 \url{https://api.delphi.cmu.edu/epidata/admin/registration_form}
 }
 \seealso{
-\code{\link[usethis:edit]{usethis::edit_r_environ()}} to automatically edit the \code{.Renviron}
-file; \code{\link[usethis:edit]{usethis::edit_r_profile()}} to automatically edit the \code{.Rprofile}
+\code{\link[usethis:edit_r_environ]{usethis::edit_r_environ()}} to automatically edit the \code{.Renviron}
+file; \code{\link[usethis:edit_r_profile]{usethis::edit_r_profile()}} to automatically edit the \code{.Rprofile}
 file
 }


### PR DESCRIPTION
fix #188 

since the default for [max_size in cache_disk](https://cachem.r-lib.org/reference/cache_disk.html) is `1024 * 1024^2`, a double, that argument can eat doubles, so remove the `as.integer` cast that's overflowing