### PR TITLE
fix: actual license details

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@
 ^.env$
 ^README\.Rmd$
 ^CRAN-SUBMISSION$
+^LICENSE\.md$

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2023
-COPYRIGHT HOLDER: Logan Brooks, Ryan Tibshirani
+COPYRIGHT HOLDER: epidatr authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2023 epidatr authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Following R conventions on the owners, as its ambiguous which orgs exactly would hold. Also adding the particular rights claimed...