### PR TITLE
fix: order of args in `clear_cache` positional bugs

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -185,7 +185,7 @@ set_cache <- function(cache_dir = NULL,
 #'   [`disable_cache`] to only disable without deleting, and [`cache_info`]
 #' @export
 #' @import cachem
-clear_cache <- function(disable = FALSE, ...) {
+clear_cache <- function(..., disable = FALSE) {
   if (any(!is.na(cache_environ$epidatr_cache))) {
     cache_environ$epidatr_cache$destroy()
   }

--- a/man/clear_cache.Rd
+++ b/man/clear_cache.Rd
@@ -4,12 +4,9 @@
 \alias{clear_cache}
 \title{Manually reset the cache, deleting all currently saved data and starting afresh}
 \usage{
-clear_cache(disable = FALSE, ...)
+clear_cache(..., disable = FALSE)
 }
 \arguments{
-\item{disable}{instead of setting a new cache, disable caching entirely;
-defaults to \code{FALSE}}
-
 \item{...}{
   Arguments passed on to \code{\link[=set_cache]{set_cache}}
   \describe{
@@ -29,6 +26,9 @@ variable is \code{EPIDATR_CACHE_LOGFILE}.}
     \item{\code{confirm}}{whether to confirm directory creation. default is \code{TRUE};
 should only be set in non-interactive scripts}
   }}
+
+\item{disable}{instead of setting a new cache, disable caching entirely;
+defaults to \code{FALSE}}
 }
 \value{
 \code{\link{NULL}} no return value, all effects are stored in the package

--- a/man/get_api_key.Rd
+++ b/man/get_api_key.Rd
@@ -52,7 +52,7 @@ Delphi Epidata API Registration Form.
 \url{https://api.delphi.cmu.edu/epidata/admin/registration_form}
 }
 \seealso{
-\code{\link[usethis:edit]{usethis::edit_r_environ()}} to automatically edit the \code{.Renviron}
-file; \code{\link[usethis:edit]{usethis::edit_r_profile()}} to automatically edit the \code{.Rprofile}
+\code{\link[usethis:edit_r_environ]{usethis::edit_r_environ()}} to automatically edit the \code{.Renviron}
+file; \code{\link[usethis:edit_r_profile]{usethis::edit_r_profile()}} to automatically edit the \code{.Rprofile}
 file
 }

--- a/man/get_api_key.Rd
+++ b/man/get_api_key.Rd
@@ -52,7 +52,7 @@ Delphi Epidata API Registration Form.
 \url{https://api.delphi.cmu.edu/epidata/admin/registration_form}
 }
 \seealso{
-\code{\link[usethis:edit_r_environ]{usethis::edit_r_environ()}} to automatically edit the \code{.Renviron}
-file; \code{\link[usethis:edit_r_profile]{usethis::edit_r_profile()}} to automatically edit the \code{.Rprofile}
+\code{\link[usethis:edit]{usethis::edit_r_environ()}} to automatically edit the \code{.Renviron}
+file; \code{\link[usethis:edit]{usethis::edit_r_profile()}} to automatically edit the \code{.Rprofile}
 file
 }


### PR DESCRIPTION
minor fix for if someone calls `clear_cache(someDir)` to reset the cache, rather than `clear_cache(dir = someDir)`