### PR TITLE
Deploy docs website on push/pull to `dev`, since we don't have a `main` branch

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,9 +5,9 @@
 # update the documentation web site on pushes to `dev` branch.
 on:
   push:
-    branches: [main]
+    branches: [dev]
   pull_request:
-    branches: [main]
+    branches: [dev]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Website wasn't updating because workflow never triggered.