### PR TITLE
Support public and dev docs site

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,9 +5,9 @@
 # update the documentation web site on pushes to `dev` branch.
 on:
   push:
-    branches: [dev]
+    branches: [main, dev]
   pull_request:
-    branches: [dev]
+    branches: [main, dev]
   release:
     types: [published]
   workflow_dispatch:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epidatr
 Type: Package
 Title: Client for Delphi's 'Epidata' API
-Version: 1.1.0
+Version: 1.1.0.9000
 Date: 2023-09-11
 Authors@R: 
   c(

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,15 +36,15 @@ R -e 'devtools::document()'
 python -m http.server -d docs
 ```
 
+For `pkgdown` to correctly generate both public (`main`) and `dev` documentation sites, the package version in `DESCRIPTION` on `dev` must have four components, and be of the format `x.x.x.9000`. The package version on `main` must be in the format `x.x.x`.
+
+The documentation website is updated on push or pull request to the `main` and `dev` branches.
+
 ## Release process
 
 ### Manual
 
 TBD
-
-For `pkgdown` to correctly generate both public (`main`) and `dev` documentation sites, the package version in `DESCRIPTION` on `dev` must have four components, and be of the format `x.x.x.9000`. The package version on `main` must be in the format `x.x.x`.
-
-The documentation website is updated on push or pull request to the `main` and `dev` branches.
 
 ### Automated (currently unavailable)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,8 +58,3 @@ The release consists of multiple steps which can be all done via the GitHub webs
    2. create another [Pull Request](https://github.com/cmu-delphi/epidatr/pulls) to merge the changes back to the `dev` branch
    3. create a [GitHub release](https://github.com/cmu-delphi/epidatr/releases) with automatically derived release notes
 5. Release to CRAN
-
-[mit-image]: https://img.shields.io/badge/License-MIT-yellow.svg
-[mit-url]: https://opensource.org/license/MIT
-[github-actions-image]: https://github.com/cmu-delphi/epidatr/workflows/ci/badge.svg
-[github-actions-url]: https://github.com/cmu-delphi/epidatr/actions

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,19 +1,52 @@
-## Development Environment
-
-Relevant R commands
+## Setting up the development environment
 
 ```r
 install.packages(c('devtools', 'pkgdown', 'styler', 'lintr')) # install dev dependencies
 devtools::install_deps(dependencies = TRUE) # install package dependencies
 devtools::document() # generate package meta data and man files
 devtools::build() # build package
+
+```
+
+## Validating the package
+
+```r
 styler::style_pkg() # format code
-lintr::lint_package() # lint package
+lintr::lint_package() # lint code
+
 devtools::test() # test package
 devtools::check() # check package for errors
 ```
 
-## Release Process
+## Developing the documentation site
+
+The [documentation site](https://cmu-delphi.github.io/epidatr/) is built off of the `main` branch. The `dev` version of the site is available at https://cmu-delphi.github.io/epidatr/dev.
+
+The documentation site can be previewed locally by running in R
+
+```r
+pkgdown::build_site(preview=TRUE)
+```
+
+The `main` version is available at `file:///<local path>/epidatr/docs/index.html` and `dev` at `file:///<local path>/epidatr/docs/dev/index.html`.
+
+You can also build the docs manually and launch the site with python. From the terminal, this looks like
+```bash
+R -e 'devtools::document()'
+python -m http.server -d docs
+```
+
+## Release process
+
+### Manual
+
+TBD
+
+For `pkgdown` to correctly generate both public (`main`) and `dev` documentation sites, the package version in `DESCRIPTION` on `dev` must have four components, and be of the format `x.x.x.9000`. The package version on `main` must be in the format `x.x.x`.
+
+The documentation website is updated on push or pull request to the `main` and `dev` branches.
+
+### Automated (currently unavailable)
 
 The release consists of multiple steps which can be all done via the GitHub website:
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -8,6 +8,9 @@ template:
     navbar-bg: '#C41230'
     navbar-fg: '#f8f8f8'
 
+development:
+  mode: auto
+
 navbar:
   bg: '#C41230'
   fg: '#f8f8f8'


### PR DESCRIPTION
https://github.com/cmu-delphi/epidatr/pull/213 keeps the doc website updated, but it matches `dev` rather than any CRAN release. If people go from CRAN to our documentation, they're going to see docs for a version they don't have. However, we'd also like to be able to see a preview of the `dev` version of the docs.

`pkgdown` lets you build doc websites from [both releases and development branches](https://pkgdown.r-lib.org/reference/build_site.html#development-mode). This PR turns on that feature, and publishes the doc site on push/pull to both `main` (reinstated to commit https://github.com/cmu-delphi/epidatr/commit/0adb796a54aee22cc54f9e1d0a724492892267b9, when [`CRAN-SUBMISSION`](https://github.com/cmu-delphi/epidatr/blob/dev/CRAN-SUBMISSION) was changed last) and `dev`. The `dev` site will be available at https://cmu-delphi.github.io/epidatr/dev; main/public at https://cmu-delphi.github.io/epidatr.

The dev website must be build from a version with 4 components (e.g. `1.1.1.1`). I've added `.9000` to the version number on `dev` to meet that requirement, but we'll need to remove it as part of the release process, since `main` needs to have a 3-part version number.