### PR TITLE
Add more detail to `avail_endpoint` descriptions

### DIFF
--- a/R/avail_endpoints.R
+++ b/R/avail_endpoints.R
@@ -22,5 +22,6 @@ avail_endpoints <- function() {
     Endpoint = paste0(h$Name, "()"),
     Description = h$Title
   )
+  cli::cli_inform(c("i" = "Data is available for the US only, unless otherwise specified"))
   tib %>% print(n = 50)
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1103,7 +1103,7 @@ pub_fluview_meta <- function(fetch_args = fetch_args_list()) {
       create_epidata_field_info("latest_issue", "date"),
       create_epidata_field_info("table_rows", "int")
     )
-  )
+  ) %>% fetch(fetch_args = fetch_args)
 }
 
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1,4 +1,4 @@
-#' CDC page hits
+#' CDC total and by topic webpage visits
 #'
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/cdc.html>
@@ -51,7 +51,7 @@ pvt_cdc <- function(auth, locations, epiweeks, fetch_args = fetch_args_list()) {
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' COVID hospitalization facility identifiers
+#' Helper for finding COVID hospitalization facilities
 #'
 #' @description
 #' API docs:
@@ -135,7 +135,7 @@ pub_covid_hosp_facility_lookup <- function(
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' COVID hospitalization data for specific facilities
+#' COVID hospitalizations by facility
 #'
 #' @description
 #' API docs:
@@ -437,7 +437,7 @@ pub_covid_hosp_facility <- function(
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' COVID hospitalization data by state
+#' COVID hospitalizations by state
 #'
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/covid_hosp.html>.
@@ -647,7 +647,7 @@ pub_covidcast_meta <- function(fetch_args = fetch_args_list()) {
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' COVID data via the covidcast endpoint
+#' Various COVID and flu signals via the COVIDcast endpoint
 #'
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html>
@@ -790,7 +790,7 @@ pub_covidcast <- function(
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Delphi's ILINet forecasts
+#' Delphi's ILINet outpatient doctor visits forecasts
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/delphi.html>
 #'
@@ -821,7 +821,7 @@ pub_delphi <- function(system, epiweek, fetch_args = fetch_args_list()) {
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Delphi's PAHO Dengue nowcast
+#' Delphi's PAHO dengue nowcasts (North and South America)
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/dengue_nowcast.html>
 #'
@@ -855,7 +855,7 @@ pub_dengue_nowcast <- function(locations, epiweeks, fetch_args = fetch_args_list
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Dengue digital surveillance sensors in PAHO member countries
+#' PAHO dengue digital surveillance sensors (North and South America)
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/dengue_sensors.html>
 #'
@@ -900,7 +900,7 @@ pvt_dengue_sensors <- function(auth, names, locations, epiweeks, fetch_args = fe
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' ECDC ILI data
+#' ECDC ILI incidence (Europe)
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/ecdc_ili.html>.
 #'
@@ -958,11 +958,11 @@ pub_ecdc_ili <- function(regions, epiweeks, ..., issues = NULL, lag = NULL, fetc
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' FluSurv hospitalization data
+#' CDC FluSurv flu hospitalizations
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/flusurv.html>.
 #'
-#' Obtain information on flu hospitalization rates from the Center of Disease
+#' Obtain information on influenza hospitalization rates from the Center of Disease
 #' Control.
 #'
 #' See also <https://gis.cdc.gov/GRASP/Fluview/FluHospRates.html>.
@@ -1022,7 +1022,7 @@ pub_flusurv <- function(locations, epiweeks, ..., issues = NULL, lag = NULL, fet
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' FluView virological data from clinical labs
+#' CDC FluView flu tests from clinical labs
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/fluview_clinical.html>
 #'
@@ -1080,7 +1080,7 @@ pub_fluview_clinical <- function(regions, epiweeks, ..., issues = NULL, lag = NU
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' FluView metadata
+#' Metadata for the FluView endpoint
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/fluview_meta.html>
 #' Returns information about the fluview endpoint.
@@ -1092,6 +1092,7 @@ pub_fluview_clinical <- function(regions, epiweeks, ..., issues = NULL, lag = NU
 #' @param fetch_args [`fetch_args`]. Additional arguments to pass to `fetch()`.
 #'
 #' @return [`tibble::tibble`]
+#' @seealso [`pub_fluview()`]
 #' @keywords endpoint
 #' @export
 pub_fluview_meta <- function(fetch_args = fetch_args_list()) {
@@ -1107,7 +1108,7 @@ pub_fluview_meta <- function(fetch_args = fetch_args_list()) {
 }
 
 
-#' FluView ILINet data
+#' CDC FluView ILINet outpatient doctor visits
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/fluview.html>. For
 #'
@@ -1192,7 +1193,7 @@ pub_fluview <- function(
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Google Flu Trends data
+#' Google Flu Trends flu search volume
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/gft.html>
 #'
@@ -1234,7 +1235,7 @@ pub_gft <- function(locations, epiweeks, fetch_args = fetch_args_list()) {
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Google Health Trends data
+#' Google Health Trends health topics search volume
 #'
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/ght.html>
@@ -1281,7 +1282,7 @@ pvt_ght <- function(auth, locations, epiweeks, query, fetch_args = fetch_args_li
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' KCDC ILI data
+#' KCDC ILI incidence (Korea)
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/kcdc_ili.html>
 #'
@@ -1332,7 +1333,7 @@ pub_kcdc_ili <- function(regions, epiweeks, ..., issues = NULL, lag = NULL, fetc
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' NoroSTAT metadata
+#' Metadata for the NoroSTAT endpoint
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/meta_norostat.html>
 #'
@@ -1343,6 +1344,7 @@ pub_kcdc_ili <- function(regions, epiweeks, ..., issues = NULL, lag = NULL, fetc
 #' @param auth string. Restricted access key (not the same as API key).
 #' @param fetch_args [`fetch_args`]. Additional arguments to pass to `fetch()`.
 #' @return [`list`]
+#' @seealso [`pvt_norostat()`]
 #' @keywords endpoint
 #' @export
 pvt_meta_norostat <- function(auth, fetch_args = fetch_args_list()) {
@@ -1355,7 +1357,7 @@ pvt_meta_norostat <- function(auth, fetch_args = fetch_args_list()) {
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' API metadata
+#' Metadata for the Delphi Epidata API
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/meta.html>
 #'
@@ -1368,7 +1370,7 @@ pub_meta <- function(fetch_args = fetch_args_list()) {
   create_epidata_call("meta/", list(), only_supports_classic = TRUE) %>% fetch(fetch_args = fetch_args)
 }
 
-#' NIDSS dengue data
+#' NIDSS dengue cases (Taiwan)
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/nidss_dengue.html>
 #'
@@ -1408,7 +1410,7 @@ pub_nidss_dengue <- function(locations, epiweeks, fetch_args = fetch_args_list()
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' NIDSS flu data
+#' NIDSS flu doctor visits (Taiwan)
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/nidss_flu.html>
 #'
@@ -1466,8 +1468,10 @@ pub_nidss_flu <- function(regions, epiweeks, ..., issues = NULL, lag = NULL, fet
 }
 
 
-#' NoroSTAT data (point data, no min/max)
+#' CDC NoroSTAT norovirus outbreaks
 #' @description
+#' This is point data only, and does not include minima or maxima.
+#'
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/norostat.html>
 #'
 #' This is the documentation of the API for accessing the NoroSTAT (norostat)
@@ -1509,7 +1513,7 @@ pvt_norostat <- function(auth, locations, epiweeks, fetch_args = fetch_args_list
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Delphi's ILI nowcast
+#' Delphi's ILI Nearby nowcasts
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/nowcast.html>.
 #'
@@ -1545,7 +1549,7 @@ pub_nowcast <- function(locations, epiweeks, fetch_args = fetch_args_list()) {
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' PAHO Dengue data
+#' PAHO dengue data (North and South America)
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/paho_dengue.html>
 #'
@@ -1640,7 +1644,7 @@ pvt_quidel <- function(auth, locations, epiweeks, fetch_args = fetch_args_list()
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Digital surveillance sensors
+#' Influenza and dengue digital surveillance sensors
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/sensors.html>
 #'
@@ -1696,7 +1700,7 @@ pvt_sensors <- function(auth, names, locations, epiweeks, fetch_args = fetch_arg
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' HealthTweets data
+#' HealthTweets total and influenza-related tweets
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/twitter.html>
 #'
@@ -1757,7 +1761,7 @@ pvt_twitter <- function(auth, locations, ..., dates = NULL, epiweeks = NULL, fet
   ) %>% fetch(fetch_args = fetch_args)
 }
 
-#' Wikipedia access data
+#' Wikipedia webpage counts by article
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/wiki.html>
 #

--- a/man/pub_covid_hosp_facility.Rd
+++ b/man/pub_covid_hosp_facility.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_covid_hosp_facility}
 \alias{pub_covid_hosp_facility}
-\title{COVID hospitalization data for specific facilities}
+\title{COVID hospitalizations by facility}
 \usage{
 pub_covid_hosp_facility(
   hospital_pks,

--- a/man/pub_covid_hosp_facility_lookup.Rd
+++ b/man/pub_covid_hosp_facility_lookup.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_covid_hosp_facility_lookup}
 \alias{pub_covid_hosp_facility_lookup}
-\title{COVID hospitalization facility identifiers}
+\title{Helper for finding COVID hospitalization facilities}
 \usage{
 pub_covid_hosp_facility_lookup(
   ...,

--- a/man/pub_covid_hosp_state_timeseries.Rd
+++ b/man/pub_covid_hosp_state_timeseries.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_covid_hosp_state_timeseries}
 \alias{pub_covid_hosp_state_timeseries}
-\title{COVID hospitalization data by state}
+\title{COVID hospitalizations by state}
 \usage{
 pub_covid_hosp_state_timeseries(
   states,

--- a/man/pub_covidcast.Rd
+++ b/man/pub_covidcast.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_covidcast}
 \alias{pub_covidcast}
-\title{COVID data via the covidcast endpoint}
+\title{Various COVID and flu signals via the COVIDcast endpoint}
 \usage{
 pub_covidcast(
   source,

--- a/man/pub_delphi.Rd
+++ b/man/pub_delphi.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_delphi}
 \alias{pub_delphi}
-\title{Delphi's ILINet forecasts}
+\title{Delphi's ILINet outpatient doctor visits forecasts}
 \usage{
 pub_delphi(system, epiweek, fetch_args = fetch_args_list())
 }

--- a/man/pub_dengue_nowcast.Rd
+++ b/man/pub_dengue_nowcast.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_dengue_nowcast}
 \alias{pub_dengue_nowcast}
-\title{Delphi's PAHO Dengue nowcast}
+\title{Delphi's PAHO dengue nowcasts (North and South America)}
 \usage{
 pub_dengue_nowcast(locations, epiweeks, fetch_args = fetch_args_list())
 }

--- a/man/pub_ecdc_ili.Rd
+++ b/man/pub_ecdc_ili.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_ecdc_ili}
 \alias{pub_ecdc_ili}
-\title{ECDC ILI data}
+\title{ECDC ILI incidence (Europe)}
 \usage{
 pub_ecdc_ili(
   regions,

--- a/man/pub_flusurv.Rd
+++ b/man/pub_flusurv.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_flusurv}
 \alias{pub_flusurv}
-\title{FluSurv hospitalization data}
+\title{CDC FluSurv flu hospitalizations}
 \usage{
 pub_flusurv(
   locations,
@@ -34,7 +34,7 @@ the most recent issue is returned. Mutually exclusive with \code{issues}.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/flusurv.html}.
 
-Obtain information on flu hospitalization rates from the Center of Disease
+Obtain information on influenza hospitalization rates from the Center of Disease
 Control.
 
 See also \url{https://gis.cdc.gov/GRASP/Fluview/FluHospRates.html}.

--- a/man/pub_fluview.Rd
+++ b/man/pub_fluview.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_fluview}
 \alias{pub_fluview}
-\title{FluView ILINet data}
+\title{CDC FluView ILINet outpatient doctor visits}
 \usage{
 pub_fluview(
   regions,

--- a/man/pub_fluview_clinical.Rd
+++ b/man/pub_fluview_clinical.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_fluview_clinical}
 \alias{pub_fluview_clinical}
-\title{FluView virological data from clinical labs}
+\title{CDC FluView flu tests from clinical labs}
 \usage{
 pub_fluview_clinical(
   regions,

--- a/man/pub_fluview_meta.Rd
+++ b/man/pub_fluview_meta.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_fluview_meta}
 \alias{pub_fluview_meta}
-\title{FluView metadata}
+\title{Metadata for the FluView endpoint}
 \usage{
 pub_fluview_meta(fetch_args = fetch_args_list())
 }
@@ -21,5 +21,8 @@ Returns information about the fluview endpoint.
 pub_fluview_meta()
 }
 
+}
+\seealso{
+\code{\link[=pub_fluview]{pub_fluview()}}
 }
 \keyword{endpoint}

--- a/man/pub_gft.Rd
+++ b/man/pub_gft.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_gft}
 \alias{pub_gft}
-\title{Google Flu Trends data}
+\title{Google Flu Trends flu search volume}
 \usage{
 pub_gft(locations, epiweeks, fetch_args = fetch_args_list())
 }

--- a/man/pub_kcdc_ili.Rd
+++ b/man/pub_kcdc_ili.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_kcdc_ili}
 \alias{pub_kcdc_ili}
-\title{KCDC ILI data}
+\title{KCDC ILI incidence (Korea)}
 \usage{
 pub_kcdc_ili(
   regions,

--- a/man/pub_meta.Rd
+++ b/man/pub_meta.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_meta}
 \alias{pub_meta}
-\title{API metadata}
+\title{Metadata for the Delphi Epidata API}
 \usage{
 pub_meta(fetch_args = fetch_args_list())
 }

--- a/man/pub_nidss_dengue.Rd
+++ b/man/pub_nidss_dengue.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_nidss_dengue}
 \alias{pub_nidss_dengue}
-\title{NIDSS dengue data}
+\title{NIDSS dengue cases (Taiwan)}
 \usage{
 pub_nidss_dengue(locations, epiweeks, fetch_args = fetch_args_list())
 }

--- a/man/pub_nidss_flu.Rd
+++ b/man/pub_nidss_flu.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_nidss_flu}
 \alias{pub_nidss_flu}
-\title{NIDSS flu data}
+\title{NIDSS flu doctor visits (Taiwan)}
 \usage{
 pub_nidss_flu(
   regions,

--- a/man/pub_nowcast.Rd
+++ b/man/pub_nowcast.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_nowcast}
 \alias{pub_nowcast}
-\title{Delphi's ILI nowcast}
+\title{Delphi's ILI Nearby nowcasts}
 \usage{
 pub_nowcast(locations, epiweeks, fetch_args = fetch_args_list())
 }

--- a/man/pub_paho_dengue.Rd
+++ b/man/pub_paho_dengue.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_paho_dengue}
 \alias{pub_paho_dengue}
-\title{PAHO Dengue data}
+\title{PAHO dengue data (North and South America)}
 \usage{
 pub_paho_dengue(
   regions,

--- a/man/pub_wiki.Rd
+++ b/man/pub_wiki.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pub_wiki}
 \alias{pub_wiki}
-\title{Wikipedia access data}
+\title{Wikipedia webpage counts by article}
 \usage{
 pub_wiki(
   articles,

--- a/man/pvt_cdc.Rd
+++ b/man/pvt_cdc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pvt_cdc}
 \alias{pvt_cdc}
-\title{CDC page hits}
+\title{CDC total and by topic webpage visits}
 \usage{
 pvt_cdc(auth, locations, epiweeks, fetch_args = fetch_args_list())
 }

--- a/man/pvt_dengue_sensors.Rd
+++ b/man/pvt_dengue_sensors.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pvt_dengue_sensors}
 \alias{pvt_dengue_sensors}
-\title{Dengue digital surveillance sensors in PAHO member countries}
+\title{PAHO dengue digital surveillance sensors (North and South America)}
 \usage{
 pvt_dengue_sensors(
   auth,

--- a/man/pvt_ght.Rd
+++ b/man/pvt_ght.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pvt_ght}
 \alias{pvt_ght}
-\title{Google Health Trends data}
+\title{Google Health Trends health topics search volume}
 \usage{
 pvt_ght(auth, locations, epiweeks, query, fetch_args = fetch_args_list())
 }

--- a/man/pvt_meta_norostat.Rd
+++ b/man/pvt_meta_norostat.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pvt_meta_norostat}
 \alias{pvt_meta_norostat}
-\title{NoroSTAT metadata}
+\title{Metadata for the NoroSTAT endpoint}
 \usage{
 pvt_meta_norostat(auth, fetch_args = fetch_args_list())
 }
@@ -21,5 +21,8 @@ API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/meta_norostat.htm
 \dontrun{
 pvt_meta_norostat(auth = Sys.getenv("SECRET_API_AUTH_NOROSTAT"))
 }
+}
+\seealso{
+\code{\link[=pvt_norostat]{pvt_norostat()}}
 }
 \keyword{endpoint}

--- a/man/pvt_norostat.Rd
+++ b/man/pvt_norostat.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pvt_norostat}
 \alias{pvt_norostat}
-\title{NoroSTAT data (point data, no min/max)}
+\title{CDC NoroSTAT norovirus outbreaks}
 \usage{
 pvt_norostat(auth, locations, epiweeks, fetch_args = fetch_args_list())
 }
@@ -19,6 +19,8 @@ pvt_norostat(auth, locations, epiweeks, fetch_args = fetch_args_list())
 \code{\link[tibble:tibble]{tibble::tibble}}
 }
 \description{
+This is point data only, and does not include minima or maxima.
+
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/norostat.html}
 
 This is the documentation of the API for accessing the NoroSTAT (norostat)

--- a/man/pvt_sensors.Rd
+++ b/man/pvt_sensors.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pvt_sensors}
 \alias{pvt_sensors}
-\title{Digital surveillance sensors}
+\title{Influenza and dengue digital surveillance sensors}
 \usage{
 pvt_sensors(auth, names, locations, epiweeks, fetch_args = fetch_args_list())
 }

--- a/man/pvt_twitter.Rd
+++ b/man/pvt_twitter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/endpoints.R
 \name{pvt_twitter}
 \alias{pvt_twitter}
-\title{HealthTweets data}
+\title{HealthTweets total and influenza-related tweets}
 \usage{
 pvt_twitter(
   auth,


### PR DESCRIPTION
Clarify data source, region, and what types of diseases and signals are available. Add message that most data is US only.