### PR TITLE
Support version params `as_of` and `issues` passed as Date objects

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -29,8 +29,8 @@ check_is_recent <- function(dates, max_age) {
 #'
 #' @keywords internal
 check_is_cachable <- function(epidata_call, fetch_args) {
-  as_of_cachable <- (!is.null(epidata_call$params$as_of) && epidata_call$params$as_of != "*")
-  issues_cachable <- (!is.null(epidata_call$params$issues) && all(epidata_call$params$issues != "*"))
+  as_of_cachable <- (!is.null(epidata_call$params$as_of) && !identical(epidata_call$params$as_of, "*"))
+  issues_cachable <- (!is.null(epidata_call$params$issues) && all(!identical(epidata_call$params$issues, "*")))
   is_cachable <- (
     !is.null(cache_environ$epidatr_cache) &&
       (as_of_cachable || issues_cachable) &&

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -58,7 +58,7 @@ test_that("check_is_cachable can handle both str and date inputs of various leng
   epidata_call$params$as_of <- NULL
   epidata_call$params$issues <- c(as.Date("2022-01-01"), as.Date("2022-02-01"))
   expect_no_error(check_is_cachable(epidata_call, fetch_args))
-  
+
   # issues epirange
   epidata_call$params$as_of <- NULL
   epidata_call$params$issues <- epirange(as.Date("2022-01-01"), as.Date("2022-02-01"))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -20,3 +20,42 @@ test_that("format_list", {
   expect_identical(format_list(list("5", "6")), "5,6")
   expect_identical(format_list(list("*", "*")), "*,*")
 })
+
+test_that("check_is_cachable can handle both str and date inputs of various lengths", {
+  epidata_call <- list(
+    params = list(as_of = NULL, issues = NULL)
+  )
+  fetch_args <- fetch_args_list()
+
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
+
+  # as_of string
+  epidata_call$params$as_of <- "2022-01-01"
+  epidata_call$params$issues <- NULL
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
+
+  # as_of date
+  epidata_call$params$as_of <- as.Date("2022-01-01")
+  epidata_call$params$issues <- NULL
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
+
+  # issues single string
+  epidata_call$params$as_of <- NULL
+  epidata_call$params$issues <- "2022-01-01"
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
+
+  # issues string vector
+  epidata_call$params$as_of <- NULL
+  epidata_call$params$issues <- c("2022-01-01", "2022-02-01")
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
+
+  # issues single date
+  epidata_call$params$as_of <- NULL
+  epidata_call$params$issues <- as.Date("2022-01-01")
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
+
+  # issues date vector
+  epidata_call$params$as_of <- NULL
+  epidata_call$params$issues <- c(as.Date("2022-01-01"), as.Date("2022-02-01"))
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -58,4 +58,9 @@ test_that("check_is_cachable can handle both str and date inputs of various leng
   epidata_call$params$as_of <- NULL
   epidata_call$params$issues <- c(as.Date("2022-01-01"), as.Date("2022-02-01"))
   expect_no_error(check_is_cachable(epidata_call, fetch_args))
+  
+  # issues epirange
+  epidata_call$params$as_of <- NULL
+  epidata_call$params$issues <- epirange(as.Date("2022-01-01"), as.Date("2022-02-01"))
+  expect_no_error(check_is_cachable(epidata_call, fetch_args))
 })


### PR DESCRIPTION
Closes [#192](https://github.com/cmu-delphi/epidatr/issues/192) and #194.

When `as_of` or `issues` is provided a Date, the comparison `as_of != "*"` tries and fails to convert "\*" to a Date also so it can do the comparison. Instead, use `identical`, which doesn't try to implicitly convert the "\*".

