### PR TITLE
lastest_issue is an epiweek, not a date

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1338,7 +1338,7 @@ pub_fluview_meta <- function(fetch_args = fetch_args_list()) {
     list(),
     list(
       create_epidata_field_info("latest_update", "date"),
-      create_epidata_field_info("latest_issue", "date"),
+      create_epidata_field_info("latest_issue", "epiweek"),
       create_epidata_field_info("table_rows", "int")
     )
   ) %>% fetch(fetch_args = fetch_args)


### PR DESCRIPTION
Because of the switch in https://github.com/cmu-delphi/epidatr/pull/223 to using `as.Date(tryFormats = ...)` instead of `as.Date(format = ...)`, failed parsing behavior has changed. Now if a value doesn't match any of the provided formats, `as.Date` errors.

This has caused `pub_fluview_meta` to start failing. One of the fields is in YYYYWW (epiweek) format, but was being parsed as a date. Presumably with the old code, this was always being replaced with NA when the parsing failed. Ask for it to be formatted as an epiweek instead.