### PR TITLE
Parse int fields as double so large values don't get set to NA

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -157,7 +157,18 @@ parse_value <- function(info, value, disable_date_parsing = FALSE) {
     return(as.logical(value))
   } else if (info$type == "int") {
     # Int doesn't have enough capacity to store some weekly `pub_wiki` values.
-    return(as.double(value))
+    value <- as.double(value)
+    if (any(value != round(value))) {
+      cli::cli_warn(
+        c(
+          "Values in {info$name} were expected to be integers but contain a decimal component",
+          "i" = "Decimal components are returned as-is"
+        ),
+        class = "epidatr__int_nonzero_decimal_digits"
+      )
+    }
+
+    return(value)
   } else if (info$type == "float") {
     return(as.double(value))
   } else if (info$type == "categorical") {

--- a/R/model.R
+++ b/R/model.R
@@ -156,7 +156,8 @@ parse_value <- function(info, value, disable_date_parsing = FALSE) {
   } else if (info$type == "bool") {
     return(as.logical(value))
   } else if (info$type == "int") {
-    return(as.integer(value))
+    # Int doesn't have enough capacity to store some weekly `pub_wiki` values.
+    return(as.double(value))
   } else if (info$type == "float") {
     return(as.double(value))
   } else if (info$type == "categorical") {

--- a/man/covidcast_epidata.Rd
+++ b/man/covidcast_epidata.Rd
@@ -69,7 +69,7 @@ the \code{pub_covidcast()} function. Simply use the \verb{$call} attribute of th
 #> 4 pa        smoothed_~ fb-su~ state    day       2021-04-08        NA 2021-04-13
 #> 5 pa        smoothed_~ fb-su~ state    day       2021-04-09        NA 2021-04-14
 #> 6 pa        smoothed_~ fb-su~ state    day       2021-04-10        NA 2021-04-15
-#> # i 7 more variables: lag <int>, missing_value <int>, missing_stderr <int>,
-#> #   missing_sample_size <int>, value <dbl>, stderr <dbl>, sample_size <dbl>
+#> # i 7 more variables: lag <dbl>, missing_value <dbl>, missing_stderr <dbl>,
+#> #   missing_sample_size <dbl>, value <dbl>, stderr <dbl>, sample_size <dbl>
 }\if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -113,7 +113,6 @@ test_that("parse_data_frame warns when df contains int values with decimal compo
   result <- parse_data_frame(epidata_call, mock_df)
   expect_type(result$lag, "double")
 
-
   # Replace int fields with decimal
   mock_df$lag <- 4.3
 

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -113,10 +113,10 @@ test_that("parse_data_frame warns when df contains int values with decimal compo
   result <- parse_data_frame(epidata_call, mock_df)
   expect_type(result$lag, "double")
 
-  
+
   # Replace int fields with decimal
   mock_df$lag <- 4.3
-  
+
   # Warning when int values have a decimal component
   expect_warning(
     parse_data_frame(epidata_call, mock_df),

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -100,6 +100,30 @@ test_that("parse_data_frame warns when df contains fields not listed in meta", {
   expect_no_warning(parse_data_frame(epidata_call, mock_df))
 })
 
+test_that("parse_data_frame warns when df contains int values with decimal component", {
+  epidata_call <- pub_flusurv(
+    locations = "ca",
+    epiweeks = 202001,
+    fetch_args = fetch_args_list(dry_run = TRUE)
+  )
+  # see generate_test_data.R
+  mock_df <- as.data.frame(readr::read_rds(testthat::test_path("data/flusurv-epiweeks.rds")))
+
+  # Int fields are returned as double
+  result <- parse_data_frame(epidata_call, mock_df)
+  expect_type(result$lag, "double")
+
+  
+  # Replace int fields with decimal
+  mock_df$lag <- 4.3
+  
+  # Warning when int values have a decimal component
+  expect_warning(
+    parse_data_frame(epidata_call, mock_df),
+    class = "epidatr__int_nonzero_decimal_digits"
+  )
+})
+
 test_that("parse_api_date accepts str and int input", {
   expect_identical(parse_api_date("20200101"), as.Date("2020-01-01"))
   expect_identical(parse_api_date(20200101), as.Date("2020-01-01"))


### PR DESCRIPTION
Some values (e.g. 2542264861) returned by `pub_wiki` are being coerced to NA [here](https://github.com/cmu-delphi/epidatr/blob/ff68c4551aaf375c7b7a5fe4621f16ae24eed2be/R/model.R#L159) because they exceed R's int storage capacity.