### PR TITLE
ci+docs: match style with epipredict

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,7 +41,13 @@ jobs:
       - name: Build site
         env:
           DELPHI_EPIDATA_KEY: ${{ secrets.SECRET_EPIDATR_GHACTIONS_DELPHI_EPIDATA_KEY }}
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: |
+          if (startsWith("${{ github.event_name }}", "pull_request")) {
+              mode <- ifelse("${{ github.base_ref }}" == "main", "release", "devel")
+          } else {
+              mode <- ifelse("${{ github.ref_name }}" == "main", "release", "devel")
+          }
+          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, override=list(PKGDOWN_DEV_MODE=mode))
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ env
 /Meta/
 .secrets
 epidatr.Rproj
+renv.lock
+renv/
+.Rprofile

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,37 +1,29 @@
+# Colors should stay consistent across epipredict & epidatr, using Carnegie
+# Red https://www.cmu.edu/brand/brand-guidelines/visual-identity/colors.html
 template:
   bootstrap: 5
   bootswatch: cosmo
   bslib:
     font_scale: 1.0
-    primary: '#C41230'
-    link-color: '#C41230'
-    navbar-bg: '#C41230'
-    navbar-fg: '#f8f8f8'
-
-development:
-  mode: auto
+    primary: "#C41230"
+    link-color: "#C41230"
 
 navbar:
-  bg: '#C41230'
-  fg: '#f8f8f8'
+  bg: primary
+  type: dark
 
 home:
   links:
     - text: Get the Python client
       href: https://github.com/cmu-delphi/epidatpy/
-
     - text: View the Delphi Website
       href: https://delphi.cmu.edu/
-      
     - text: Introduction to Delphi's Tooling Work
       href: https://cmu-delphi.github.io/delphi-tooling-book/
-    
     - text: The epiprocess R package
       href: https://cmu-delphi.github.io/epiprocess/
-    
     - text: The epipredict R package
       href: https://cmu-delphi.github.io/epipredict/
-    
     - text: The epidatasets R package
       href: https://cmu-delphi.github.io/epidatasets/
 


### PR DESCRIPTION
Header bar text is unreadable on [epidatr/dev](https://cmu-delphi.github.io/epidatr/dev/) docs, fix by matching the settings in `_pkgdown.yml` with the [settings in epipredict ](https://github.com/cmu-delphi/epipredict/blob/dev/_pkgdown.yml), which [look correct](https://cmu-delphi.github.io/epipredict/). I tested this locally with: `build_home_index(); init_site()` and then `python -m http.server` to host.

![image](https://github.com/cmu-delphi/epidatr/assets/1810426/7e0e18ea-5439-4816-a4bd-2b98e7547d58)

Also matches the pkgdown ci with how it's done in epiprocess (based on branch instead of .9000 version numbers).