### PR TITLE
repo+doc: follow version conventions from epiprocess

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### Checklist
+
+Please:
+
+- [ ] Make sure this PR is against "dev", not "main".
+- [ ] Request a review from one of the current epiprocess main reviewers:
+      brookslogan, nmdefries.
+- [ ] Makes sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
+      Always increment the patch version number (the third number), unless you are
+      making a release PR from dev to main, in which case increment the minor
+      version number (the second number).
+- [ ] Describe changes made in NEWS.md, making sure breaking changes
+      (backwards-incompatible changes to the documented interface) are noted.
+      Collect the changes under the next release number (e.g. if you are on
+      1.7.2, then write your changes under the 1.8 heading).
+
+### Change explanations for reviewer
+
+### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
+
+- Resolves #{issue number}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epidatr
 Type: Package
 Title: Client for Delphi's 'Epidata' API
-Version: 1.0.0.9000
+Version: 1.0.1
 Date: 2023-12-07
 Authors@R:
   c(

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,6 @@ install.packages(c('devtools', 'pkgdown', 'styler', 'lintr')) # install dev depe
 devtools::install_deps(dependencies = TRUE) # install package dependencies
 devtools::document() # generate package meta data and man files
 devtools::build() # build package
-
 ```
 
 ## Validating the package
@@ -20,41 +19,39 @@ devtools::check() # check package for errors
 
 ## Developing the documentation site
 
-The [documentation site](https://cmu-delphi.github.io/epidatr/) is built off of the `main` branch. The `dev` version of the site is available at https://cmu-delphi.github.io/epidatr/dev.
+Our CI is setup to build the [main documentation site](https://cmu-delphi.github.io/epidatr/) off of the `main` branch, while the [`dev` version of the site](https://cmu-delphi.github.io/epidatr/dev) is built off the `dev` branch.
 
-The documentation site can be previewed locally by running in R
+The documentation site can be previewed locally by running in R:
 
 ```r
+# Should automatically open a browser
 pkgdown::build_site(preview=TRUE)
 ```
 
-The `main` version is available at `file:///<local path>/epidatr/docs/index.html` and `dev` at `file:///<local path>/epidatr/docs/dev/index.html`.
+If the above does not open a browser, you can try using a Python server from the command line:
 
-You can also build the docs manually and launch the site with python. From the terminal, this looks like
 ```bash
 R -e 'devtools::document()'
+R -e 'pkgdown::build_site()'
 python -m http.server -d docs
 ```
 
-For `pkgdown` to correctly generate both public (`main`) and `dev` documentation sites, the package version in `DESCRIPTION` on `dev` must have four components, and be of the format `x.x.x.9000`. The package version on `main` must be in the format `x.x.x`.
+## Versioning
 
-The documentation website is updated on push or pull request to the `main` and `dev` branches.
+Please follow the guidelines in the PR template document (reproduced here):
+
+- [ ] Make sure this PR is against "dev", not "main".
+- [ ] Request a review from one of the current epiprocess main reviewers:
+      brookslogan, nmdefries.
+- [ ] Makes sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
+      Always increment the patch version number (the third number), unless you are
+      making a release PR from dev to main, in which case increment the minor
+      version number (the second number).
+- [ ] Describe changes made in NEWS.md, making sure breaking changes
+      (backwards-incompatible changes to the documented interface) are noted.
+      Collect the changes under the next release number (e.g. if you are on
+      0.7.2, then write your changes under the 0.8 heading).
 
 ## Release process
 
-### Manual
-
 TBD
-
-### Automated (currently unavailable)
-
-The release consists of multiple steps which can be all done via the GitHub website:
-
-1. Go to [create_release GitHub Action](https://github.com/cmu-delphi/epidatr/actions/workflows/create_release.yml) and click the `Run workflow` button. Enter the next version number or one of the magic keywords (patch, minor, major) and hit the green `Run workflow` button.
-2. The action will prepare a new release and will end up with a new [Pull Request](https://github.com/cmu-delphi/epidatr/pulls)
-3. Let the code owner review the PR and its changes and let the CI check whether everything builds successfully
-4. Once approved and merged, another GitHub action job starts which automatically will
-   1. create a git tag
-   2. create another [Pull Request](https://github.com/cmu-delphi/epidatr/pulls) to merge the changes back to the `dev` branch
-   3. create a [GitHub release](https://github.com/cmu-delphi/epidatr/releases) with automatically derived release notes
-5. Release to CRAN

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,10 @@ devtools::check() # check package for errors
 
 ## Developing the documentation site
 
-Our CI is setup to build the [main documentation site](https://cmu-delphi.github.io/epidatr/) off of the `main` branch, while the [`dev` version of the site](https://cmu-delphi.github.io/epidatr/dev) is built off the `dev` branch.
+Our CI builds two version of the documentation:
+
+- https://cmu-delphi.github.io/epidatr/ from the `main` branch and
+- https://cmu-delphi.github.io/epidatr/dev from the `dev` branch.
 
 The documentation site can be previewed locally by running in R:
 
@@ -28,7 +31,8 @@ The documentation site can be previewed locally by running in R:
 pkgdown::build_site(preview=TRUE)
 ```
 
-If the above does not open a browser, you can try using a Python server from the command line:
+If the above does not open a browser, you can try using a Python server from the
+command line:
 
 ```bash
 R -e 'devtools::document()'
@@ -38,19 +42,7 @@ python -m http.server -d docs
 
 ## Versioning
 
-Please follow the guidelines in the PR template document (reproduced here):
-
-- [ ] Make sure this PR is against "dev", not "main".
-- [ ] Request a review from one of the current epiprocess main reviewers:
-      brookslogan, nmdefries.
-- [ ] Makes sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
-      Always increment the patch version number (the third number), unless you are
-      making a release PR from dev to main, in which case increment the minor
-      version number (the second number).
-- [ ] Describe changes made in NEWS.md, making sure breaking changes
-      (backwards-incompatible changes to the documented interface) are noted.
-      Collect the changes under the next release number (e.g. if you are on
-      0.7.2, then write your changes under the 0.8 heading).
+Please follow the guidelines in the [PR template document](.github/pull_request_template.md).
 
 ## Release process
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# epidatr 1.0.0.9000
+# epidatr 1.1.0
 
 - Function reference now displays commonly-used functions first (#205).
 - Endpoints now fail when passed misspelled arguments (#187, #201).


### PR DESCRIPTION
- Change version number to 1.0.1 ("first PR" of 1.0.0)
- Change the news heading from 1.0.0.9000 to 1.1.0 (next release version)