### PR TITLE
CI: docs also includes the readme

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -44,6 +44,7 @@ jobs:
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add README.md
           git add man/\* NAMESPACE DESCRIPTION
           git commit -m "docs: document (GHA)" || echo "No changes to commit"
           git pull --rebase


### PR DESCRIPTION
### Checklist

Please:

- [X] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [X] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [NA] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [NA] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer
we're also building the docs using `README.rmd`. But the docs gh action didn't add the readme as a man page. This fixes that.
