### PR TITLE
If `as_of` sent to `check_is_recent` is a `Date`, compare to a `Date` threshold.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epidatr
 Type: Package
 Title: Client for Delphi's 'Epidata' API
-Version: 1.1.0
+Version: 1.1.1
 Authors@R:
   c(
     person("Logan", "Brooks", email = "lcbrooks@andrew.cmu.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# epidatr 1.2.0
+# epidatr 1.1.1
 
 ## Changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# epidatr 1.2.0
+
+## Changes
+
+## Features
+
+## Patches
+- Fixed failure when passing `as_of` values in `Date` format to
+  `pub_covidcast` while caching is enabled (#259)
+
 # epidatr 1.1.0
 
 ## Changes

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,7 +22,12 @@ format_list <- function(values) {
 #'
 #' @keywords internal
 check_is_recent <- function(dates, max_age) {
-  (!is.null(dates) && any(dates >= format(Sys.Date() - max_age, format = "%Y%m%d")))
+  if (inherits(dates, "Date")) {
+    threshold <- Sys.Date() - max_age
+  } else {
+    threshold <- format(Sys.Date() - max_age, format = "%Y%m%d")
+  }
+  (!is.null(dates) && any(dates >= threshold))
 }
 
 #' helper that checks whether a call is actually cachable

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -65,6 +65,33 @@ test_that("check_is_cachable can handle both str and date inputs of various leng
   expect_no_error(check_is_cachable(epidata_call, fetch_args))
 })
 
+test_that("check_is_recent can handle both str and date inputs of various lengths", {
+  # NULL
+  as_of <- NULL
+  expect_no_error(result <- check_is_recent(as_of, 10))
+  expect_identical(result, FALSE)
+
+  # as_of single string
+  as_of <- "2022-01-01"
+  expect_no_error(result <- check_is_recent(as_of, 10))
+  expect_identical(result, FALSE)
+
+  # as_of string vector
+  as_of <- c("2022-01-01", "3000-01-02", "3000-01-03")
+  expect_no_error(result <- check_is_recent(as_of, 10))
+  expect_identical(result, TRUE)
+
+  # as_of single date
+  as_of <- as.Date("2022-01-01")
+  expect_no_error(result <- check_is_recent(as_of, 10))
+  expect_identical(result, FALSE)
+
+  # as_of date vector
+  as_of <- as.Date(c("2022-01-01", "3000-01-02", "3000-01-03"))
+  expect_no_error(result <- check_is_recent(as_of, 10))
+  expect_identical(result, TRUE)
+})
+
 test_that("get_wildcard_equivalent_dates works in basic cases", {
   # Week date
   result <- get_wildcard_equivalent_dates(epirange(202002, 202013), "week")


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer
If `as_of` sent to `check_is_recent` is a `Date`, compare to a `Date` threshold.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

Closes https://github.com/cmu-delphi/epidatr/issues/258
