### PR TITLE
ci: fix pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,7 +23,7 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      DELPHI_EPIDATA_KEY: ${{ secrets.DELPHI_GITHUB_ACTIONS_EPIDATA_API_KEY }}
+      DELPHI_EPIDATA_KEY: ${{ secrets.SECRET_EPIDATR_GHACTIONS_DELPHI_EPIDATA_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -39,8 +39,6 @@ jobs:
           needs: website
 
       - name: Build site
-        env:
-          DELPHI_EPIDATA_KEY: ${{ secrets.SECRET_EPIDATR_GHACTIONS_DELPHI_EPIDATA_KEY }}
         run: |
           if (startsWith("${{ github.event_name }}", "pull_request")) {
               mode_ref <- ifelse("${{ github.base_ref }}" == "main", "release", "devel")

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -43,11 +43,16 @@ jobs:
           DELPHI_EPIDATA_KEY: ${{ secrets.SECRET_EPIDATR_GHACTIONS_DELPHI_EPIDATA_KEY }}
         run: |
           if (startsWith("${{ github.event_name }}", "pull_request")) {
-              mode <- ifelse("${{ github.base_ref }}" == "main", "release", "devel")
+              mode_ref <- ifelse("${{ github.base_ref }}" == "main", "release", "devel")
           } else {
-              mode <- ifelse("${{ github.ref_name }}" == "main", "release", "devel")
+              mode_ref <- ifelse("${{ github.ref_name }}" == "main", "release", "devel")
           }
-          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, override=list(PKGDOWN_DEV_MODE=mode))
+          library(pkgdown)
+          pkg <-  as_pkgdown(".", overide = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev", PKGDOWN_DEV_MODE = mode_ref)))
+          cli::cli_rule("Cleaning files from odl site")
+          clean_site(pkg)
+          build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)
+          build_github_pages(pkg)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -49,7 +49,7 @@ jobs:
           }
           library(pkgdown)
           pkg <-  as_pkgdown(".", override = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev"), PKGDOWN_DEV_MODE = mode_ref))
-          cli::cli_rule("Cleaning files from odl site")
+          cli::cli_rule("Cleaning files from old site")
           clean_site(pkg)
           build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)
           build_github_pages(pkg)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -52,7 +52,7 @@ jobs:
           cli::cli_rule("Cleaning files from old site")
           clean_site(pkg)
           build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)
-          build_github_pages(pkg)
+          pkgdown:::build_github_pages(pkg)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -48,7 +48,7 @@ jobs:
               mode_ref <- ifelse("${{ github.ref_name }}" == "main", "release", "devel")
           }
           library(pkgdown)
-          pkg <-  as_pkgdown(".", overide = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev"), PKGDOWN_DEV_MODE = mode_ref))
+          pkg <-  as_pkgdown(".", override = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev"), PKGDOWN_DEV_MODE = mode_ref))
           cli::cli_rule("Cleaning files from odl site")
           clean_site(pkg)
           build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -48,7 +48,7 @@ jobs:
               mode_ref <- ifelse("${{ github.ref_name }}" == "main", "release", "devel")
           }
           library(pkgdown)
-          pkg <-  as_pkgdown(".", overide = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev", PKGDOWN_DEV_MODE = mode_ref)))
+          pkg <-  as_pkgdown(".", overide = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev"), PKGDOWN_DEV_MODE = mode_ref))
           cli::cli_rule("Cleaning files from odl site")
           clean_site(pkg)
           build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, local::., any::cli
           needs: website
 
       - name: Build site
@@ -45,11 +45,10 @@ jobs:
           } else {
               mode_ref <- ifelse("${{ github.ref_name }}" == "main", "release", "devel")
           }
-          library(pkgdown)
-          pkg <-  as_pkgdown(".", override = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev"), PKGDOWN_DEV_MODE = mode_ref))
-          cli::cli_rule("Cleaning files from old site")
-          clean_site(pkg)
-          build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)
+          pkg <- pkgdown::as_pkgdown(".", override = list(destination = ifelse(mode_ref == "release", "docs", "docs/dev"), PKGDOWN_DEV_MODE = mode_ref))
+          cli::cli_rule("Cleaning files from old site...")
+          pkgdown::clean_site(pkg)
+          pkgdown::build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)
           pkgdown:::build_github_pages(pkg)
         shell: Rscript {0}
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,5 +70,5 @@ get_wildcard_equivalent_dates <- function(time_value, time_type = c("day", "week
 #' inserts each string as a bullet at the end of the "Prepare for release" section
 #' @keywords internal
 release_bullets <- function() {
-  c("merge to main", "don't use_version('patch') in the next section", "`use_version('patch')` is redundant because we do this in PRs","`use_dev_version` is also redundant.")
+  c("merge to main", "don't use_version('patch') in the next section", "`use_version('patch')` is redundant because we do this in PRs", "`use_dev_version` is also redundant.")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,5 +70,10 @@ get_wildcard_equivalent_dates <- function(time_value, time_type = c("day", "week
 #' inserts each string as a bullet at the end of the "Prepare for release" section
 #' @keywords internal
 release_bullets <- function() {
-  c("merge to main", "don't use_version('patch') in the next section", "`use_version('patch')` is redundant because we do this in PRs", "`use_dev_version` is also redundant.")
+  c(
+    "merge to main",
+    "don't use_version('patch') in the next section",
+    "`use_version('patch')` is redundant because we do this in PRs",
+    "`use_dev_version` is also redundant."
+  )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,5 +72,3 @@ get_wildcard_equivalent_dates <- function(time_value, time_type = c("day", "week
 release_bullets <- function() {
   c("merge to main", "don't use_version('patch') in the next section", "`use_version('patch')` is redundant because we do this in PRs","`use_dev_version` is also redundant.")
 }
-
-pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, override=list(PKGDOWN_DEV_MODE=mode_ref))

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,5 +70,7 @@ get_wildcard_equivalent_dates <- function(time_value, time_type = c("day", "week
 #' inserts each string as a bullet at the end of the "Prepare for release" section
 #' @keywords internal
 release_bullets <- function() {
-  c("merge to main")
+  c("merge to main", "don't use_version('patch') in the next section", "`use_version('patch')` is redundant because we do this in PRs","`use_dev_version` is also redundant.")
 }
+
+pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, override=list(PKGDOWN_DEV_MODE=mode_ref))

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,7 @@
 # Colors should stay consistent across epipredict & epidatr, using Carnegie
 # Red https://www.cmu.edu/brand/brand-guidelines/visual-identity/colors.html
+development:
+  mode: devel
 template:
   bootstrap: 5
   bootswatch: cosmo


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

CI seems to be misbehaving and we're getting the `dev` branch docs on the main page. Try to fix with [Github variables](https://docs.github.com/en/actions/learn-github-actions/variables) instead of [contexts](https://docs.github.com/en/actions/learn-github-actions/contexts#determining-when-to-use-contexts).

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
