### PR TITLE
Turn off endpoint missing checks for `geo_values` and `time_values`, which have defaults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epidatr
 Type: Package
 Title: Client for Delphi's 'Epidata' API
-Version: 1.1.1
+Version: 1.1.3
 Authors@R:
   c(
     person("Logan", "Brooks", email = "lcbrooks@andrew.cmu.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Patches
 - Fixed failure when passing `as_of` values in `Date` format to
   `pub_covidcast` while caching is enabled (#259)
+- Fix failure in `pub_covidcast` when user doesn't pass `geo_values` or `time_values`, even though those arguments have defaults (#268).
 
 # epidatr 1.1.0
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -961,9 +961,9 @@ pub_covidcast_meta <- function(fetch_args = fetch_args_list()) {
 #'   <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html>).
 #' @param time_type string. The temporal resolution of the data (either "day" or
 #' "week", depending on signal).
-#' @param geo_values character. The geographies to return. "*" fetches
-#'   all. (See:
-#'   <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html>.)
+#' @param geo_values character. The geographies to return. Defaults to all
+#'  ("*") geographies within requested geographic resolution (see:
+#'  <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html>.).
 #' @param time_values [`timeset`]. Dates to fetch. Defaults to all ("*") dates.
 #' @param ... not used for values, forces later arguments to bind by name
 #' @param as_of Date. Optionally, the as of date for the issues to fetch. If not

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1001,13 +1001,17 @@ pub_covidcast <- function(
       missing(time_type) ||
       missing(geo_type)
   ) {
-    stop(
-      "`source`, `signals`, `time_type`, and `geo_type` are all required"
+    cli::cli_abort(
+      "`source`, `signals`, `time_type`, and `geo_type` are all required",
+      class = "epidatr__pub_covidcast__missing_required_args"
     )
   }
 
   if (sum(!is.null(issues), !is.null(lag), !is.null(as_of)) > 1) {
-    stop("`issues`, `lag`, and `as_of` are mutually exclusive")
+    cli::cli_abort(
+      "`issues`, `lag`, and `as_of` are mutually exclusive",
+      class = "epidatr__pub_covidcast__too_many_issue_params"
+    )
   }
 
   assert_character_param("data_source", source, len = 1)

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -999,12 +999,10 @@ pub_covidcast <- function(
     missing(source) ||
       missing(signals) ||
       missing(time_type) ||
-      missing(geo_type) ||
-      missing(time_values) ||
-      missing(geo_values)
+      missing(geo_type)
   ) {
     stop(
-      "`source`, `signals`, `time_type`, `geo_type`, `time_values`, and `geo_values` are all required"
+      "`source`, `signals`, `time_type`, and `geo_type` are all required"
     )
   }
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -576,9 +576,10 @@ pub_covid_hosp_state_timeseries <- function(
   # Check parameters
   rlang::check_dots_empty()
 
-  if (missing(states) || missing(dates)) {
-    stop(
-      "`states` and `dates` are both required"
+  if (missing(states)) {
+    cli::cli_abort(
+      "`states` is required",
+      class = "epidatr__pub_covid_hosp_state_timeseries__missing_required_args"
     )
   }
 

--- a/man/pub_covidcast.Rd
+++ b/man/pub_covidcast.Rd
@@ -31,9 +31,9 @@ pub_covidcast(
 \item{time_type}{string. The temporal resolution of the data (either "day" or
 "week", depending on signal).}
 
-\item{geo_values}{character. The geographies to return. "*" fetches
-all. (See:
-\url{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html}.)}
+\item{geo_values}{character. The geographies to return. Defaults to all
+("*") geographies within requested geographic resolution (see:
+\url{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html}.).}
 
 \item{time_values}{\code{\link{timeset}}. Dates to fetch. Defaults to all ("*") dates.}
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -570,3 +570,14 @@ test_that("pub_covidcast catches missing args for args without defaults", {
     class = "epidatr__pub_covidcast__missing_required_args"
   )
 })
+
+test_that("pub_covid_hosp_state_timeseries catches missing args for args without defaults", {
+  expect_no_error(pub_covid_hosp_state_timeseries(
+    states = "fl",
+    fetch_args = fetch_args_list(dry_run = TRUE)
+  ))
+  expect_error(
+    pub_covid_hosp_state_timeseries(),
+    class = "epidatr__pub_covid_hosp_state_timeseries__missing_required_args"
+  )
+})

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -517,3 +517,45 @@ test_that("pub_covid_hosp_state_timeseries supports versioned queries", {
   expect_identical(epidata_call$params$as_of, 20220101)
   expect_identical(epidata_call$params$lag, NULL)
 })
+
+test_that("pub_covidcast catches missing args for args without defaults", {
+  expect_no_error(pub_covidcast(
+    source = "jhu-csse",
+    signals = "confirmed_7dav_incidence_prop",
+    time_type = "day",
+    geo_type = "state",
+    fetch_args = fetch_args_list(dry_run = TRUE)
+  ))
+  expect_error(
+    pub_covidcast(
+      signals = "confirmed_7dav_incidence_prop",
+      time_type = "day",
+      geo_type = "state"
+    ),
+    class = "epidatr__pub_covidcast__missing_required_args"
+  )
+  expect_error(
+    pub_covidcast(
+      source = "jhu-csse",
+      time_type = "day",
+      geo_type = "state"
+    ),
+    class = "epidatr__pub_covidcast__missing_required_args"
+  )
+  expect_error(
+    pub_covidcast(
+      source = "jhu-csse",
+      signals = "confirmed_7dav_incidence_prop",
+      geo_type = "state"
+    ),
+    class = "epidatr__pub_covidcast__missing_required_args"
+  )
+  expect_error(
+    pub_covidcast(
+      source = "jhu-csse",
+      signals = "confirmed_7dav_incidence_prop",
+      time_type = "day"
+    ),
+    class = "epidatr__pub_covidcast__missing_required_args"
+  )
+})


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

`missing` doesn't count default values as non-missing. If a user doesn't pass `geo_values` or `time_values` (both of which default to "*" in `pub_covidcast`), or `dates` (in `pub_covid_hosp_state_timeseries`), the `missing` check fails. To avoid this, just don't check missingness of those two arguments.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
