### PR TITLE
fix: improve reading of `EPIDATR_USE_CACHE` variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epidatr
 Type: Package
 Title: Client for Delphi's 'Epidata' API
-Version: 1.1.3
+Version: 1.1.4
 Authors@R:
   c(
     person("Logan", "Brooks", email = "lcbrooks@andrew.cmu.edu", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# epidatr 1.2.0
+
+## Changes
+
+- Improve handling of the `EPIDATR_USE_CACHE` environment variable, allowing it
+  to be any value convertable by `as.logical()` and handle the case when it
+  can't be converted.
+
 # epidatr 1.1.1
 
 ## Changes
@@ -5,6 +13,7 @@
 ## Features
 
 ## Patches
+
 - Fix failure when passing `as_of` values in `Date` format to
   `pub_covidcast` while caching is enabled (#259).
 - For `pub_covidcast` data source `nchs-mortality`, parse dates as `epiweek`
@@ -15,6 +24,7 @@
 # epidatr 1.1.0
 
 ## Changes
+
 - `pub_covid_hosp_state_timeseries` now supports use of the `as_of` parameter (#209).
 - `release_date` and `latest_update` fields are now parsed as `Date`, rather
   than as text. This change impacts several endpoints.
@@ -22,14 +32,18 @@
 - `get_api_key` no longer reads from R options and only uses environment variables (#217).
 - `pvt_twitter` and `pub_wiki` now use `time_type` and `time_values` args instead of mutually exclusive `dates` and `epiweeks` (#236). This matches the interface of the `pub_covidcast` endpoint.
 - Updated the default `timeout_seconds` to 15 minutes to allow large queries by default.
+
 ## Features
+
 - Function reference now displays commonly-used functions first (#205).
 - Support `Date` objects passed to version arguments `as_of` and `issues` in
   endpoints (#192, #194).
 - `clear_cache` now handles positional arguments just like `set_cache` (#197).
 - `set_api_key` now available to help persist API key environment variables (#181, #217).
 - All endpoints now support the use of "\*" as a wildcard to fetch all dates or epiweeks (#234).
+
 ## Patches
+
 - Endpoints now fail when passed misspelled arguments (#187, #201).
 - `pub_fluview_meta` fixed to `fetch` the response automatically.
 - `pub_covid_hosp_state_timeseries` now correctly parses the `issue` field,

--- a/R/epidatr-package.R
+++ b/R/epidatr-package.R
@@ -8,8 +8,14 @@
 "_PACKAGE"
 
 .onLoad <- function(libname, pkgname) {
-  cache_environ$use_cache <- Sys.getenv("EPIDATR_USE_CACHE", unset = FALSE)
-  cache_environ$use_cache <- (cache_environ$use_cache == "TRUE")
+  cache_environ$use_cache <- as.logical(Sys.getenv("EPIDATR_USE_CACHE", unset = FALSE))
+  if (is.na(cache_environ$use_cache)) {
+    cli::cli_warn(
+      "Failed to read EPIDATR_USE_CACHE environment variable.
+        Should be a logical. Defaulting to FALSE."
+    )
+    cache_environ$use_cache <- FALSE
+  }
   if (cache_environ$use_cache) {
     set_cache(startup = TRUE)
   }


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

`EPIDATR_USE_CACHE` only supported exactly "TRUE" before. Now it supports all logical values and includes a warning when any value that can't be converted to logical is provided.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
