### PR TITLE
Support "YYYY-MM-DD" format in `date_to_epiweek`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epidatr
 Type: Package
 Title: Client for Delphi's 'Epidata' API
-Version: 1.1.4
+Version: 1.1.5
 Authors@R:
   c(
     person("Logan", "Brooks", email = "lcbrooks@andrew.cmu.edu", role = c("aut")),

--- a/R/model.R
+++ b/R/model.R
@@ -239,7 +239,7 @@ parse_data_frame <- function(epidata_call, df, disable_date_parsing = FALSE) {
 #' @importFrom MMWRweek MMWRweek
 #' @keywords internal
 date_to_epiweek <- function(value) {
-  date_components <- MMWRweek::MMWRweek(as.Date(as.character(value), "%Y%m%d"))
+  date_components <- MMWRweek::MMWRweek(parse_api_date(value))
   as.numeric(paste0(
     date_components$MMWRyear,
     # Pad with zeroes up to 2 digits (x -> 0x)


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer
Support more date formats in function to convert dates to epiweeks. Use `parse_api_date` since it already supports both common formats.
