### PR TITLE
docs: improve strange wording on getting started page

### DIFF
--- a/vignettes/epidatr.Rmd
+++ b/vignettes/epidatr.Rmd
@@ -117,7 +117,9 @@ pub_covidcast(
 )
 ```
 
-We can fetch a subset of states by listing out the desired locations:
+Alternatively, we can fetch the full time series for a subset of states by 
+listing out the desired locations in the `geo_value` argument and using `*`
+in the `time_values` argument:
 
 ```{r, eval = FALSE}
 # Obtain the most up-to-date version of the smoothed covid-like illness (CLI)
@@ -128,24 +130,8 @@ pub_covidcast(
   geo_type = "state",
   time_type = "day",
   geo_values = c("pa", "ca", "fl"),
-  time_values = epirange(20210105, 20210410)
+  time_values = "*"
 )
-```
-
-We can also request data for a single location at a time, via the `geo_values` argument.
-
-```{r}
-# Obtain the most up-to-date version of the smoothed covid-like illness (CLI)
-# signal from the COVID-19 Trends and Impact survey for Pennsylvania
-epidata <- pub_covidcast(
-  source = "fb-survey",
-  signals = "smoothed_cli",
-  geo_type = "state",
-  time_type = "day",
-  geo_values = "pa",
-  time_values = epirange(20210105, 20210410)
-)
-knitr::kable(head(epidata))
 ```
 
 ## Getting versioned data


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [ ] ~~Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).~~
- [ ] ~~Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).~~

### Change explanations for reviewer

Found some strange wording in the migration to epidatpy. It helps to read the [section in context](https://cmu-delphi.github.io/epidatr/articles/epidatr.html#basic-usage) to see that it gets weird (Ctrl + F "We can also request data for a single location at a time").

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
