### PR TITLE
enh: meta endpoints bypass cache by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epidatr
 Title: Client for Delphi's 'Epidata' API
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: c(
     person("Logan", "Brooks", , "lcbrooks@andrew.cmu.edu", role = "aut"),
     person("Dmitry", "Shemetov", , "dshemeto@andrew.cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+
+
+# epidatr 1.2.3
+
+## Changes
+
+- Make sure `*_meta` functions bypass the cache by default.
+
 # epidatr 1.2.2
 
 ## Changes

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -885,6 +885,8 @@ pub_covid_hosp_state_timeseries <- function(
 #' available, the geographic levels at which they are reported, and etc.
 #'
 #' @param fetch_args [`fetch_args`]. Additional arguments to pass to `fetch()`.
+#'   By default, the cache is refreshed (since we anticipate the user will want
+#'   to see the latest metadata).
 #'
 #' @return [`tibble::tibble`]
 #'
@@ -896,7 +898,7 @@ pub_covid_hosp_state_timeseries <- function(
 #' @seealso [pub_covidcast()],[covidcast_epidata()]
 #' @keywords endpoint
 #' @export
-pub_covidcast_meta <- function(fetch_args = fetch_args_list()) {
+pub_covidcast_meta <- function(fetch_args = fetch_args_list(refresh_cache=TRUE)) {
   create_epidata_call(
     "covidcast_meta/",
     list(),
@@ -1466,12 +1468,13 @@ pub_fluview_clinical <- function(
 #' }
 #'
 #' @param fetch_args [`fetch_args`]. Additional arguments to pass to `fetch()`.
+#' Set `refresh_cache=TRUE` to force a refresh of the cache.
 #'
 #' @return [`tibble::tibble`]
 #' @seealso [`pub_fluview()`]
 #' @keywords endpoint
 #' @export
-pub_fluview_meta <- function(fetch_args = fetch_args_list()) {
+pub_fluview_meta <- function(fetch_args = fetch_args_list(refresh_cache=TRUE)) {
   create_epidata_call(
     "fluview_meta/",
     list(),
@@ -1746,11 +1749,12 @@ pub_kcdc_ili <- function(
 #' }
 #' @param auth string. Restricted access key (not the same as API key).
 #' @param fetch_args [`fetch_args`]. Additional arguments to pass to `fetch()`.
+#' Set `refresh_cache=TRUE` to force a refresh of the cache.
 #' @return [`list`]
 #' @seealso [`pvt_norostat()`]
 #' @keywords endpoint
 #' @export
-pvt_meta_norostat <- function(auth, fetch_args = fetch_args_list()) {
+pvt_meta_norostat <- function(auth, fetch_args = fetch_args_list(refresh_cache=TRUE)) {
   assert_character_param("auth", auth, len = 1)
 
   create_epidata_call(
@@ -1765,11 +1769,12 @@ pvt_meta_norostat <- function(auth, fetch_args = fetch_args_list()) {
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/meta.html>
 #'
 #' @param fetch_args [`fetch_args`]. Additional arguments to pass to `fetch()`.
+#' Set `refresh_cache=TRUE` to force a refresh of the cache.
 #'
 #' @return [`list`]
 #' @keywords endpoint
 #' @export
-pub_meta <- function(fetch_args = fetch_args_list()) {
+pub_meta <- function(fetch_args = fetch_args_list(refresh_cache=TRUE)) {
   create_epidata_call("meta/", list(), only_supports_classic = TRUE) %>% fetch(fetch_args = fetch_args)
 }
 


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

Seems like a footgun to cache `*_meta` endpoints outputs, so I made them not do that by default.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
