### PR TITLE
fix: extend check_is_recent to support numeric date formats

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,8 @@
 linters: linters_with_defaults(
   line_length_linter(120),
   object_length_linter(length = 40L),
-  return_linter = NULL
+  return_linter = NULL,
+  pipe_consistency_linter = NULL
   )
 exclusions: list(
   "renv",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epidatr
 Title: Client for Delphi's 'Epidata' API
-Version: 1.2.3
+Version: 1.2.4
 Authors@R: c(
     person("Logan", "Brooks", , "lcbrooks@andrew.cmu.edu", role = "aut"),
     person("Dmitry", "Shemetov", , "dshemeto@andrew.cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@
 ## Patches
 
 
+# epidatr 1.2.4
+
+## Patches
+
+- Extend `check_is_recent` to support numeric date formats (#320).
+
 # epidatr 1.2.2
 
 ## Changes

--- a/R/model.R
+++ b/R/model.R
@@ -221,7 +221,7 @@ parse_data_frame <- function(epidata_call, df, disable_date_parsing = FALSE, ref
   }
 
   columns <- colnames(df)
-  for (i in seq_len(length(meta))) {
+  for (i in seq_along(meta)) {
     info <- meta[[i]]
     if (info$name %in% columns) {
       df[[info$name]] <- parse_value(

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,6 +24,12 @@ format_list <- function(values) {
 check_is_recent <- function(dates, max_age) {
   if (inherits(dates, "Date")) {
     threshold <- Sys.Date() - max_age
+  } else if (is.numeric(dates) && all(nchar(dates) == 6)) {
+    # Convert threshold to epiweek
+    threshold <- date_to_epiweek(Sys.Date() - max_age)
+  } else if (is.numeric(dates)) {
+    # If inputs are numerics, compare as YYYYMMDD
+    threshold <- as.numeric(format(Sys.Date() - max_age, format = "%Y%m%d"))
   } else {
     threshold <- format(Sys.Date() - max_age, format = "%Y%m%d")
   }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -90,6 +90,21 @@ test_that("check_is_recent can handle both str and date inputs of various length
   as_of <- as.Date(c("2022-01-01", "3000-01-02", "3000-01-03"))
   expect_no_error(result <- check_is_recent(as_of, 10))
   expect_identical(result, TRUE)
+
+  # as_of numeric epiweek
+  # Recent epiweek (2 days ago)
+  recent_epiweek <- date_to_epiweek(Sys.Date() - 2)
+  expect_true(check_is_recent(recent_epiweek, 7))
+  # Old epiweek (14 days ago)
+  old_epiweek <- date_to_epiweek(Sys.Date() - 14)
+  expect_false(check_is_recent(old_epiweek, 7))
+
+  # Recent integer date
+  recent_int_date <- as.numeric(format(Sys.Date() - 2, "%Y%m%d"))
+  expect_true(check_is_recent(recent_int_date, 7))
+  # Old integer date
+  old_int_date <- as.numeric(format(Sys.Date() - 14, "%Y%m%d"))
+  expect_false(check_is_recent(old_int_date, 7))
 })
 
 test_that("get_wildcard_equivalent_dates works in basic cases", {


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

The bug was caused because `check_is_recent` performed an incorrect comparison when epiweeks are provided instead of dates. This update adjusts the threshold to operate on weeks when epiweeks are used. 

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #320
