### PR TITLE
fix: disable enforcement of one pipe type over the other

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,8 @@
 linters: linters_with_defaults(
   line_length_linter(120),
   object_length_linter(length = 40L),
-  return_linter = NULL
+  return_linter = NULL,
+  pipe_consistency_linter = NULL
   )
 exclusions: list(
   "renv",

--- a/R/model.R
+++ b/R/model.R
@@ -221,7 +221,7 @@ parse_data_frame <- function(epidata_call, df, disable_date_parsing = FALSE, ref
   }
 
   columns <- colnames(df)
-  for (i in seq_len(length(meta))) {
+  for (i in seq_along(meta)) {
     info <- meta[[i]]
     if (info$name %in% columns) {
       df[[info$name]] <- parse_value(


### PR DESCRIPTION
This avoids failed checks as a consequence.

### Checklist

Please:

- [X] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [X] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [ ] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

This modification disables enforcing one pipe type over the other, preventing failed checks like [this one](https://github.com/cmu-delphi/epidatr/actions/runs/20799576138/job/59741403147?pr=329). I also replaced `seq_len(length(meta))` with `seq_along(meta)`. Lint suggests this change. Since they are functionally identical, I modified it to prevent it from being flagged. 

