### PR TITLE
doc: point to signal discovery for example queries everywhere

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,6 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Collate:
     'auth.R'
     'cache.R'
@@ -84,3 +83,4 @@ Collate:
     'request.R'
     'utils-pipe.R'
     'utils.R'
+Config/roxygen2/version: 8.0.0

--- a/R/covidcast.R
+++ b/R/covidcast.R
@@ -9,19 +9,9 @@ parse_signal <- function(signal, base_url) {
   class(signal) <- c("covidcast_data_signal", class(signal))
   signal$key <- paste(signal$source, signal$signal, sep = ":")
 
-  #' fetch covidcast data
-  #'
-  #' param data_source data source to fetch
-  #' param signals data source to fetch
-  #' param geo_type geo_type to fetch
-  #' param time_type data source to fetch
-  #' param geo_values data source to fetch
-  #' param time_values data source to fetch
-  #' param as_of data source to fetch
-  #' param issues data source to fetch
-  #' param lag data source to fetch
-  #' return an instance of epidata_call
-  #' keywords internal
+  # Inner callable returned per signal: fetches covidcast data for the bound
+  # source/signal/time_type, taking geo_type, geo_values, time_values, and the
+  # versioning args (as_of, issues, lag). Returns an epidata_call.
   signal$call <- function(geo_type,
                           geo_values,
                           time_values,

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -5,7 +5,6 @@
 #' @title Shared Documentation for epidatr Parameters
 #'
 #' @description This is a central text for parameter documentation
-#'
 #' @name .epidatr_shared_params
 #' @keywords internal
 #'
@@ -51,6 +50,10 @@
 #'
 #' See `vignette("versioned-data")` for details and more ways to specify
 #' versioned data.
+#'
+#' @section See also:
+#' For example queries showing how to discover signals and build calls,
+#' see `vignette("signal-discovery", package = "epidatr")`.
 NULL
 
 
@@ -58,6 +61,7 @@ NULL
 #'
 #' @description
 #' API docs: <https://cmu-delphi.github.io/delphi-epidata/api/cdc.html>
+#'
 #'
 #' @examples
 #' \dontrun{
@@ -74,6 +78,7 @@ NULL
 #'   for details.
 #' @return [`tibble::tibble`]
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_cdc <- function(
@@ -141,6 +146,7 @@ pvt_cdc <- function(
 #' @return [`tibble::tibble`]
 #'
 #' @seealso [`pub_covid_hosp_facility()`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_covid_hosp_facility_lookup <- function(
@@ -234,6 +240,7 @@ pub_covid_hosp_facility_lookup <- function(
 #' @importFrom checkmate test_class test_integerish test_character
 #'
 #' @seealso [`pub_covid_hosp_facility()`], [`epirange()`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 #
@@ -614,6 +621,7 @@ pub_covid_hosp_facility <- function(
 #'
 #' @return [`tibble::tibble`]
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 #
@@ -937,6 +945,7 @@ pub_covid_hosp_state_timeseries <- function(
 #' pub_covidcast_meta()
 #'
 #' @seealso [pub_covidcast()],[covidcast_epidata()]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_covidcast_meta <- function(fetch_args = fetch_args_list()) {
@@ -1015,6 +1024,7 @@ pub_covidcast_meta <- function(fetch_args = fetch_args_list()) {
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
 #' @seealso [pub_covidcast_meta()], [covidcast_epidata()], [epirange()]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_covidcast <- function(
@@ -1137,6 +1147,7 @@ pub_covidcast <- function(
 #' @inheritParams .epidatr_shared_params
 #' @return list
 #' @seealso [epidata_snapshot()], [epidata_archive()], [epidata()], [epirange()]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 epidata_meta <- function(source, fetch_args = fetch_args_list()) {
@@ -1184,6 +1195,7 @@ epidata_meta <- function(source, fetch_args = fetch_args_list()) {
 #'   Internally maps to the `version_query` parameter.
 #' @return [`tibble::tibble`]
 #' @seealso [epidata_meta()], [epirange()]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @name cast_api_queries
 NULL
@@ -1367,6 +1379,7 @@ epidata <- function(
 #' @param epiweek [`timeset`]. Epiweek to fetch. Does not support multiple dates.
 #'  Make separate calls to fetch data for multiple epiweeks.
 #' @return [`list`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_delphi <- function(
@@ -1403,6 +1416,7 @@ pub_delphi <- function(
 #' @param locations character. List of locations to fetch.
 #'   See the [codes for countries and territories in the Americas](https://cmu-delphi.github.io/delphi-epidata/api/geographic_codes.html#countries-and-territories-in-the-americas). # nolint
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_dengue_nowcast <- function(
@@ -1447,6 +1461,7 @@ pub_dengue_nowcast <- function(
 #' @param names character. List of sensor names to fetch.
 #'   See the [available sensors](https://cmu-delphi.github.io/delphi-epidata/api/dengue_sensors.html#available-sensors).
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_dengue_sensors <- function(
@@ -1502,6 +1517,7 @@ pvt_dengue_sensors <- function(
 #'
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_ecdc_ili <- function(
@@ -1567,6 +1583,7 @@ pub_ecdc_ili <- function(
 #'
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_flusurv <- function(
@@ -1656,6 +1673,7 @@ pub_flusurv <- function(
 #'
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_fluview_clinical <- function(
@@ -1714,6 +1732,7 @@ pub_fluview_clinical <- function(
 #'
 #' @return [`tibble::tibble`]
 #' @seealso [`pub_fluview()`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_fluview_meta <- function(fetch_args = fetch_args_list()) {
@@ -1752,6 +1771,7 @@ pub_fluview_meta <- function(fetch_args = fetch_args_list()) {
 #'
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_fluview <- function(
@@ -1829,6 +1849,7 @@ pub_fluview <- function(
 #' @inheritParams .epidatr_shared_params
 #'
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_gft <- function(
@@ -1875,6 +1896,7 @@ pub_gft <- function(
 #'   for details.
 #' @param query string. The query to be fetched.
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_ght <- function(
@@ -1923,6 +1945,7 @@ pvt_ght <- function(
 #'
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_kcdc_ili <- function(
@@ -1975,6 +1998,7 @@ pub_kcdc_ili <- function(
 #' @inheritParams .epidatr_shared_params
 #' @return [`list`]
 #' @seealso [`pvt_norostat()`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_meta_norostat <- function(auth, fetch_args = fetch_args_list()) {
@@ -1993,6 +2017,7 @@ pvt_meta_norostat <- function(auth, fetch_args = fetch_args_list()) {
 #' @inheritParams .epidatr_shared_params
 #'
 #' @return [`list`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_meta <- function(fetch_args = fetch_args_list()) {
@@ -2022,6 +2047,7 @@ pub_meta <- function(fetch_args = fetch_args_list()) {
 #'   for details.
 #'
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_nidss_dengue <- function(
@@ -2065,6 +2091,7 @@ pub_nidss_dengue <- function(
 #'
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_nidss_flu <- function(
@@ -2132,6 +2159,7 @@ pub_nidss_flu <- function(
 #' full state names are permitted. See the `locations` column in the
 #' output of `pvt_meta_norostat()` for the allowed values.
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_norostat <- function(
@@ -2176,6 +2204,7 @@ pvt_norostat <- function(
 #'
 #' @inheritParams .epidatr_shared_params
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_nowcast <- function(
@@ -2216,6 +2245,7 @@ pub_nowcast <- function(
 #'
 #' @inheritSection .epidatr_shared_params Data Versioning
 #'
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_paho_dengue <- function(
@@ -2279,6 +2309,7 @@ pub_paho_dengue <- function(
 #'   See [HHS regions' codes](https://cmu-delphi.github.io/delphi-epidata/api/geographic_codes.html#hhs-regions)
 #'   for details.
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_quidel <- function(
@@ -2341,6 +2372,7 @@ pvt_quidel <- function(
 #'   See the codes of the [US regions and states](https://cmu-delphi.github.io/delphi-epidata/api/geographic_codes.html#us-regions-and-states) # nolint
 #'   for details.
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_sensors <- function(
@@ -2397,6 +2429,7 @@ pvt_sensors <- function(
 #'   See the codes of the [US regions and states](https://cmu-delphi.github.io/delphi-epidata/api/geographic_codes.html#us-regions-and-states) # nolint
 #'   for details.
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pvt_twitter <- function(
@@ -2477,6 +2510,7 @@ pvt_twitter <- function(
 #' @param language string. Language to fetch.
 #' @param hours integer. Optionally, the hours to fetch.
 #' @return [`tibble::tibble`]
+#' @inheritSection .epidatr_shared_params See also
 #' @keywords endpoint
 #' @export
 pub_wiki <- function(

--- a/man/cast_api_queries.Rd
+++ b/man/cast_api_queries.Rd
@@ -96,6 +96,12 @@ available issues.
 on which versioning argument is supplied.
 }
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \seealso{
 \code{\link[=epidata_meta]{epidata_meta()}}, \code{\link[=epirange]{epirange()}}
 }

--- a/man/clear_cache.Rd
+++ b/man/clear_cache.Rd
@@ -8,7 +8,7 @@ clear_cache(..., disable = FALSE)
 }
 \arguments{
 \item{...}{
-  Arguments passed on to \code{\link[=set_cache]{set_cache}}
+  Arguments passed on to \code{\link{set_cache}}
   \describe{
     \item{\code{cache_dir}}{the directory in which the cache is stored. By default, this
 is \code{rappdirs::user_cache_dir("R", version = "epidatr")}. The path can be

--- a/man/covidcast_epidata.Rd
+++ b/man/covidcast_epidata.Rd
@@ -27,7 +27,7 @@ an object containing fields for every signal:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{epidata <- covidcast_epidata()
 epidata$signals
-#> # A tibble: 520 x 3
+#> # A tibble: 538 x 3
 #>    source        signal                        short_description                
 #>    <chr>         <chr>                         <chr>                            
 #>  1 chng          smoothed_outpatient_cli       Estimated percentage of outpatie~
@@ -40,7 +40,7 @@ epidata$signals
 #>  8 chng          7dav_outpatient_covid         Ratio of outpatient doctor visit~
 #>  9 covid-act-now pcr_specimen_positivity_rate  Proportion of PCR specimens test~
 #> 10 covid-act-now pcr_specimen_total_tests      Total number of PCR specimens te~
-#> # i 510 more rows
+#> # i 528 more rows
 }\if{html}{\out{</div>}}
 
 If you use an editor that supports tab completion, such as RStudio, type
@@ -60,9 +60,6 @@ the \code{pub_covidcast()} function. Simply use the \verb{$call} attribute of th
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{epidata$signals$`fb-survey:smoothed_cli`$call("state", "pa",
                                               epirange(20210405, 20210410))
-#> Waiting 3s for retry backoff =============>-----------------
-#> Waiting 3s for retry backoff ============================>--
-#> Waiting 3s for retry backoff =============================>-
 #> # A tibble: 6 x 15
 #>   geo_value signal     source geo_type time_type time_value direction issue     
 #>   <chr>     <chr>      <chr>  <fct>    <fct>     <date>         <dbl> <date>    

--- a/man/dot-epidatr_shared_params.Rd
+++ b/man/dot-epidatr_shared_params.Rd
@@ -65,4 +65,10 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \keyword{internal}

--- a/man/epidata_meta.Rd
+++ b/man/epidata_meta.Rd
@@ -20,6 +20,12 @@ list
 including version ranges, time value ranges, and lists of available signals
 and geo types.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \seealso{
 \code{\link[=epidata_snapshot]{epidata_snapshot()}}, \code{\link[=epidata_archive]{epidata_archive()}}, \code{\link[=epidata]{epidata()}}, \code{\link[=epirange]{epirange()}}
 }

--- a/man/parse_signal.Rd
+++ b/man/parse_signal.Rd
@@ -14,25 +14,4 @@ parse_signal(signal, base_url)
 \description{
 turn a signal into a callable
 }
-\keyword{an}
-\keyword{as_of}
-\keyword{covidcast}
-\keyword{data}
-\keyword{data_source}
-\keyword{epidata_call}
-\keyword{fetch}
-\keyword{geo_type}
-\keyword{geo_values}
-\keyword{instance}
 \keyword{internal}
-\keyword{issues}
-\keyword{keywords}
-\keyword{lag}
-\keyword{of}
-\keyword{param}
-\keyword{return}
-\keyword{signals}
-\keyword{source}
-\keyword{time_type}
-\keyword{time_values}
-\keyword{to}

--- a/man/pub_covid_hosp_facility.Rd
+++ b/man/pub_covid_hosp_facility.Rd
@@ -41,6 +41,12 @@ used to look up facility identifiers in a variety of ways.
 Starting October 1, 2022, some facilities are only required to
 report annually.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_covid_hosp_facility_lookup.Rd
+++ b/man/pub_covid_hosp_facility_lookup.Rd
@@ -47,6 +47,12 @@ facilities of interest. This is a companion endpoint to the
 Only one location argument needs to be specified.
 Combinations of the arguments are not currently supported.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_covid_hosp_state_timeseries.Rd
+++ b/man/pub_covid_hosp_state_timeseries.Rd
@@ -66,6 +66,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_covidcast.Rd
+++ b/man/pub_covidcast.Rd
@@ -82,6 +82,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_covidcast_meta.Rd
+++ b/man/pub_covidcast_meta.Rd
@@ -21,6 +21,12 @@ Fetch a summary of metadata for all sources and signals that are available in
 the API, along with basic summary statistics such as the dates they are
 available, the geographic levels at which they are reported, and etc.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_delphi.Rd
+++ b/man/pub_delphi.Rd
@@ -23,6 +23,12 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/delphi.html}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_dengue_nowcast.Rd
+++ b/man/pub_dengue_nowcast.Rd
@@ -24,6 +24,12 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/dengue_nowcast.html}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_ecdc_ili.Rd
+++ b/man/pub_ecdc_ili.Rd
@@ -66,6 +66,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_flusurv.Rd
+++ b/man/pub_flusurv.Rd
@@ -69,6 +69,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_fluview.Rd
+++ b/man/pub_fluview.Rd
@@ -77,6 +77,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_fluview_clinical.Rd
+++ b/man/pub_fluview_clinical.Rd
@@ -64,6 +64,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_fluview_meta.Rd
+++ b/man/pub_fluview_meta.Rd
@@ -16,6 +16,12 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/fluview_meta.html}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_gft.Rd
+++ b/man/pub_gft.Rd
@@ -34,6 +34,12 @@ endpoint. Possibile input for locations can be found in
 and
 \url{https://cmu-delphi.github.io/delphi-epidata/api/geographic_codes.html#selected-us-cities}.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_kcdc_ili.Rd
+++ b/man/pub_kcdc_ili.Rd
@@ -60,6 +60,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_meta.Rd
+++ b/man/pub_meta.Rd
@@ -16,4 +16,10 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/meta.html}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \keyword{endpoint}

--- a/man/pub_nidss_dengue.Rd
+++ b/man/pub_nidss_dengue.Rd
@@ -34,6 +34,12 @@ Possible location inputs can be found in
 and
 \url{https://github.com/cmu-delphi/delphi-epidata/blob/main/labels/nidss_locations.txt}.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_nidss_flu.Rd
+++ b/man/pub_nidss_flu.Rd
@@ -63,6 +63,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_nowcast.Rd
+++ b/man/pub_nowcast.Rd
@@ -30,6 +30,12 @@ The full list of location inputs can be accessed at
 \url{https://cmu-delphi.github.io/delphi-epidata/api/geographic_codes.html#us-regions-and-states}
 and \url{https://cmu-delphi.github.io/delphi-epidata/api/geographic_codes.html#fluview-cities}.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_paho_dengue.Rd
+++ b/man/pub_paho_dengue.Rd
@@ -60,6 +60,12 @@ See \code{vignette("versioned-data")} for details and more ways to specify
 versioned data.
 }
 
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pub_wiki.Rd
+++ b/man/pub_wiki.Rd
@@ -48,6 +48,12 @@ Number of page visits for selected English, Influenza-related wikipedia articles
 \item Open access
 }
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontshow{if (curl::has_internet() && Sys.getenv("DELPHI_EPIDATA_KEY") != "") withAutoprint(\{ # examplesIf}
 

--- a/man/pvt_cdc.Rd
+++ b/man/pvt_cdc.Rd
@@ -27,6 +27,12 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/cdc.html}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_cdc(

--- a/man/pvt_dengue_sensors.Rd
+++ b/man/pvt_dengue_sensors.Rd
@@ -35,6 +35,12 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/dengue_sensors.html}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_dengue_sensors(

--- a/man/pvt_ght.Rd
+++ b/man/pvt_ght.Rd
@@ -31,6 +31,12 @@ API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/ght.html}
 
 Estimate of influenza activity based on volume of certain search queries. …
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_ght(

--- a/man/pvt_meta_norostat.Rd
+++ b/man/pvt_meta_norostat.Rd
@@ -18,6 +18,12 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \description{
 API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/meta_norostat.html}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_meta_norostat(auth = Sys.getenv("DELPHI_EPIDATA_KEY"))

--- a/man/pvt_norostat.Rd
+++ b/man/pvt_norostat.Rd
@@ -32,6 +32,12 @@ API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/norostat.html}
 This is the documentation of the API for accessing the NoroSTAT endpoint of
 the Delphi’s epidemiological data.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_norostat(

--- a/man/pvt_quidel.Rd
+++ b/man/pvt_quidel.Rd
@@ -29,6 +29,12 @@ API docs: \url{https://cmu-delphi.github.io/delphi-epidata/api/quidel.html}
 
 Data provided by Quidel Corp., which contains flu lab test results.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_quidel(

--- a/man/pvt_sensors.Rd
+++ b/man/pvt_sensors.Rd
@@ -48,6 +48,12 @@ Nearby, Google Flu Trends, etc., during the COVID-19 pandemic, because
 these were designed to track ILI as driven by seasonal influenza, and were
 NOT designed to track ILI during the COVID-19 pandemic.
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_sensors(

--- a/man/pvt_twitter.Rd
+++ b/man/pvt_twitter.Rd
@@ -41,6 +41,12 @@ This is the API documentation for accessing the Twitter Stream endpoint of
 Delphi’s epidemiological data. Sourced from
 \href{http://www.healthtweets.org/}{Healthtweets}
 }
+\section{See also}{
+
+For example queries showing how to discover signals and build calls,
+see \code{vignette("signal-discovery", package = "epidatr")}.
+}
+
 \examples{
 \dontrun{
 pvt_twitter(

--- a/tests/testthat/helper-live.R
+++ b/tests/testthat/helper-live.R
@@ -1,6 +1,6 @@
 # Gate for tests that make real network calls to the Delphi Epidata API.
 # Default `devtools::test()` does NOT run these. Use `make test-live`, which
-# sets EPIDATR_LIVE_TEST=1, to enable.
+# sets EPIDATR_LIVE_TEST=TRUE, to enable.
 #
 # We use a package-specific env var (not NOT_CRAN) because testthat's
 # skip_on_cran() also enables tests in interactive R sessions — too leaky.


### PR DESCRIPTION
Making the example query vignette more visible by linking to it.