### PR TITLE
Rerouting deprecated parameters

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -38,11 +38,13 @@ jobs:
         env:
           DELPHI_EPIDATA_KEY: ${{ secrets.SECRET_EPIDATR_GHACTIONS_DELPHI_EPIDATA_KEY }}
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
 
       - name: Show testthat output
@@ -61,3 +63,6 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,8 +59,6 @@ Suggests:
     rmarkdown,
     testthat (>= 3.1.5),
     withr,
-    base64enc,
-    httr,
     curl
 VignetteBuilder:
     knitr

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1182,6 +1182,8 @@ epidata_meta <- function(source, fetch_args = fetch_args_list()) {
 #'   `report_time` column for the archive endpoint. Supports exact dates (e.g.,
 #'   `"2025-10-16"`), operators (e.g., `"<2025-10-16"`), or an [`epirange()`].
 #'   Internally maps to the `version_query` API parameter.
+#' @param version `r lifecycle::badge("deprecated")` Use `report_time` instead.
+#' @param time_values `r lifecycle::badge("deprecated")` Use `reference_time` instead.
 #' @return [`tibble::tibble`]
 #' @seealso [epidata_meta()], [epirange()]
 #' @keywords endpoint

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1196,6 +1196,7 @@ epidata_snapshot <- function(
   geo_type,
   geo_values = "*",
   reference_time = "*",
+  time_values = lifecycle::deprecated(),
   ...,
   fill_method = NULL,
   as_of = NULL,
@@ -1219,6 +1220,18 @@ epidata_snapshot <- function(
   # as_of reformatting
   if (!is.null(as_of)) as_of <- format(parse_api_date(as_of), "%Y-%m-%d")
 
+  if (lifecycle::is_present(time_values)) {
+    lifecycle::deprecate_warn(
+      "0.3.0",
+      "epidata_snapshot(time_values)",
+      details = paste(
+        "The `time_values` argument is deprecated and will be removed in a future version.",
+        "Use `reference_time` instead."
+      )
+    )
+    reference_time <- time_values
+  }
+
   parsed_reference_times <- validate_timeset_input("reference_time", reference_time)
 
   create_epidata_call(
@@ -1239,10 +1252,10 @@ epidata_snapshot <- function(
       create_epidata_field_info("reference_time", "date"),
       create_epidata_field_info("value", "float"),
       # source-specific extra columns
-      create_epidata_field_info("age_group", "text"),     # pophive
-      create_epidata_field_info("nwss_source", "text"),   # nwss
-      create_epidata_field_info("sample_index", "text"),  # nwss
-      create_epidata_field_info("pcr_target", "text")     # nwss
+      create_epidata_field_info("age_group", "text"), # pophive
+      create_epidata_field_info("nwss_source", "text"), # nwss
+      create_epidata_field_info("sample_index", "text"), # nwss
+      create_epidata_field_info("pcr_target", "text") # nwss
     ),
     api_version = "cast",
     response_format = "csv"
@@ -1259,9 +1272,11 @@ epidata_archive <- function(
   geo_type,
   geo_values = "*",
   reference_time = "*",
+  time_values = lifecycle::deprecated(),
   ...,
   fill_method = NULL,
   report_time = "*",
+  version = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 ) {
   if (missing(source) || missing(signals) || missing(geo_type)) {
@@ -1278,6 +1293,23 @@ epidata_archive <- function(
   assert_character_param("geo_type", geo_type, len = 1)
   assert_character_param("geo_values", geo_values)
   assert_character_param("fill_method", fill_method, len = 1, required = FALSE)
+
+  if (lifecycle::is_present(time_values)) {
+    lifecycle::deprecate_warn(
+      "0.3.0",
+      "epidata_archive(time_values)",
+      details = "The `time_values` argument is deprecated and will be removed in a future version. Use `reference_times` instead."
+    )
+    reference_time <- time_values
+  }
+  if (lifecycle::is_present(version)) {
+    lifecycle::deprecate_warn(
+      "0.3.0",
+      "epidata_archive(version)",
+      details = "The `version` argument is deprecated and will be removed in a future version. Use `report_time` instead."
+    )
+    report_time <- version
+  }
 
   parsed_reference_times <- validate_timeset_input("reference_time", reference_time)
   version_query <- validate_version_query(report_time)
@@ -1300,10 +1332,10 @@ epidata_archive <- function(
       create_epidata_field_info("reference_time", "date"),
       create_epidata_field_info("value", "float"),
       # source-specific extra columns
-      create_epidata_field_info("age_group", "text"),     # pophive
-      create_epidata_field_info("nwss_source", "text"),   # nwss
-      create_epidata_field_info("sample_index", "text"),  # nwss
-      create_epidata_field_info("pcr_target", "text")     # nwss
+      create_epidata_field_info("age_group", "text"), # pophive
+      create_epidata_field_info("nwss_source", "text"), # nwss
+      create_epidata_field_info("sample_index", "text"), # nwss
+      create_epidata_field_info("pcr_target", "text") # nwss
     ),
     api_version = "cast",
     response_format = "csv"

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1298,7 +1298,10 @@ epidata_archive <- function(
     lifecycle::deprecate_warn(
       "0.3.0",
       "epidata_archive(time_values)",
-      details = "The `time_values` argument is deprecated and will be removed in a future version. Use `reference_times` instead."
+      details = paste(
+        "The `time_values` argument is deprecated and will be removed in a future version.",
+        "Use `reference_time` instead."
+      )
     )
     reference_time <- time_values
   }
@@ -1306,7 +1309,10 @@ epidata_archive <- function(
     lifecycle::deprecate_warn(
       "0.3.0",
       "epidata_archive(version)",
-      details = "The `version` argument is deprecated and will be removed in a future version. Use `report_time` instead."
+      details = paste(
+        "The `version` argument is deprecated and will be removed in a future version.",
+        "Use `report_time` instead."
+      )
     )
     report_time <- version
   }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1182,9 +1182,16 @@ epidata_meta <- function(source, fetch_args = fetch_args_list()) {
 #'   `report_time` column for the archive endpoint. Supports exact dates (e.g.,
 #'   `"2025-10-16"`), operators (e.g., `"<2025-10-16"`), or an [`epirange()`].
 #'   Internally maps to the `version_query` API parameter.
-#' @param version `r lifecycle::badge("deprecated")` Use `report_time` instead.
+#' @param issues `r lifecycle::badge("deprecated")` Use `report_time` instead.
 #' @param time_values `r lifecycle::badge("deprecated")` Use `reference_time` instead.
 #' @return [`tibble::tibble`]
+#'
+#' @section Data Versioning:
+#' `epidata` supports two mutually exclusive versioning arguments. Pass `as_of`
+#' to retrieve data as it appeared on a specific date, or `report_time` to query
+#' the archive by when data was reported. If neither is supplied, `epidata`
+#' returns the latest available snapshot.
+#'
 #' @seealso [epidata_meta()], [epirange()]
 #' @keywords endpoint
 #' @name cast_api_queries
@@ -1278,7 +1285,7 @@ epidata_archive <- function(
   ...,
   fill_method = NULL,
   report_time = "*",
-  version = lifecycle::deprecated(),
+  issues = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 ) {
   if (missing(source) || missing(signals) || missing(geo_type)) {
@@ -1307,16 +1314,16 @@ epidata_archive <- function(
     )
     reference_time <- time_values
   }
-  if (lifecycle::is_present(version)) {
+  if (lifecycle::is_present(issues)) {
     lifecycle::deprecate_warn(
       "0.3.0",
-      "epidata_archive(version)",
+      "epidata_archive(issues)",
       details = paste(
-        "The `version` argument is deprecated and will be removed in a future version.",
+        "The `issues` argument is deprecated and will be removed in a future version.",
         "Use `report_time` instead."
       )
     )
-    report_time <- version
+    report_time <- issues
   }
 
   parsed_reference_times <- validate_timeset_input("reference_time", reference_time)
@@ -1365,24 +1372,24 @@ epidata <- function(
   fill_method = NULL,
   as_of = NULL,
   report_time = NULL,
-  version = lifecycle::deprecated(),
+  issues = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 ) {
-  if ((!is.null(report_time) || lifecycle::is_present(version)) && !is.null(as_of)) {
+  if ((!is.null(report_time) || lifecycle::is_present(issues)) && !is.null(as_of)) {
     cli::cli_abort(
       "`report_time` and `as_of` are mutually exclusive",
       class = "epidatr__epidata__version_and_as_of_exclusive"
     )
   }
 
-  if (!is.null(report_time) || lifecycle::is_present(version) || identical(as_of, "*")) {
+  if (!is.null(report_time) || lifecycle::is_present(issues) || identical(as_of, "*")) {
     epidata_archive(
       source = source, signals = signals, geo_type = geo_type,
       geo_values = geo_values, reference_time = reference_time,
       time_values = time_values,
       fill_method = fill_method,
       report_time = if (!is.null(report_time)) report_time else "*",
-      version = version,
+      issues = issues,
       fetch_args = fetch_args
     )
   } else {

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1360,31 +1360,36 @@ epidata <- function(
   geo_type,
   geo_values = "*",
   reference_time = "*",
+  time_values = lifecycle::deprecated(),
   ...,
   fill_method = NULL,
   as_of = NULL,
   report_time = NULL,
+  version = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 ) {
-  if (!is.null(report_time) && !is.null(as_of)) {
+  if ((!is.null(report_time) || lifecycle::is_present(version)) && !is.null(as_of)) {
     cli::cli_abort(
       "`report_time` and `as_of` are mutually exclusive",
       class = "epidatr__epidata__version_and_as_of_exclusive"
     )
   }
 
-  if (!is.null(report_time) || identical(as_of, "*")) {
+  if (!is.null(report_time) || lifecycle::is_present(version) || identical(as_of, "*")) {
     epidata_archive(
       source = source, signals = signals, geo_type = geo_type,
       geo_values = geo_values, reference_time = reference_time,
+      time_values = time_values,
       fill_method = fill_method,
       report_time = if (!is.null(report_time)) report_time else "*",
+      version = version,
       fetch_args = fetch_args
     )
   } else {
     epidata_snapshot(
       source = source, signals = signals, geo_type = geo_type,
       geo_values = geo_values, reference_time = reference_time,
+      time_values = time_values,
       fill_method = fill_method,
       as_of = as_of,
       fetch_args = fetch_args

--- a/man/cast_api_queries.Rd
+++ b/man/cast_api_queries.Rd
@@ -13,6 +13,7 @@ epidata_snapshot(
   geo_type,
   geo_values = "*",
   reference_time = "*",
+  time_values = lifecycle::deprecated(),
   ...,
   fill_method = NULL,
   as_of = NULL,
@@ -25,9 +26,11 @@ epidata_archive(
   geo_type,
   geo_values = "*",
   reference_time = "*",
+  time_values = lifecycle::deprecated(),
   ...,
   fill_method = NULL,
   report_time = "*",
+  version = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 )
 
@@ -37,10 +40,12 @@ epidata(
   geo_type,
   geo_values = "*",
   reference_time = "*",
+  time_values = lifecycle::deprecated(),
   ...,
   fill_method = NULL,
   as_of = NULL,
   report_time = NULL,
+  version = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 )
 }
@@ -59,9 +64,11 @@ geo types for a given source and signal.}
 ("*") geographies within requested geographic resolution (see:
 \url{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html}.).}
 
-\item{reference_time}{\code{\link{timeset}}. Reference dates to return (filters on the
+\item{reference_time}{\code{\link{timeset}}. Reference time to return (filters on the
 \code{reference_time} column). Supports individual dates or \code{\link[=epirange]{epirange()}}.
 Defaults to all (\code{"*"}). Filtered locally after the API call.}
+
+\item{time_values}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{reference_time} instead.}
 
 \item{...}{not used for values, forces later arguments to bind by name}
 
@@ -82,6 +89,8 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \code{report_time} column for the archive endpoint. Supports exact dates (e.g.,
 \code{"2025-10-16"}), operators (e.g., \code{"<2025-10-16"}), or an \code{\link[=epirange]{epirange()}}.
 Internally maps to the \code{version_query} API parameter.}
+
+\item{version}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{report_time} instead.}
 }
 \value{
 \code{\link[tibble:tibble]{tibble::tibble}}

--- a/man/cast_api_queries.Rd
+++ b/man/cast_api_queries.Rd
@@ -30,7 +30,7 @@ epidata_archive(
   ...,
   fill_method = NULL,
   report_time = "*",
-  version = lifecycle::deprecated(),
+  issues = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 )
 
@@ -45,7 +45,7 @@ epidata(
   fill_method = NULL,
   as_of = NULL,
   report_time = NULL,
-  version = lifecycle::deprecated(),
+  issues = lifecycle::deprecated(),
   fetch_args = fetch_args_list()
 )
 }
@@ -90,7 +90,7 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \code{"2025-10-16"}), operators (e.g., \code{"<2025-10-16"}), or an \code{\link[=epirange]{epirange()}}.
 Internally maps to the \code{version_query} API parameter.}
 
-\item{version}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{report_time} instead.}
+\item{issues}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{report_time} instead.}
 }
 \value{
 \code{\link[tibble:tibble]{tibble::tibble}}
@@ -105,6 +105,14 @@ available issues.
 on which versioning argument is supplied.
 }
 }
+\section{Data Versioning}{
+
+\code{epidata} supports two mutually exclusive versioning arguments. Pass \code{as_of}
+to retrieve data as it appeared on a specific date, or \code{report_time} to query
+the archive by when data was reported. If neither is supplied, \code{epidata}
+returns the latest available snapshot.
+}
+
 \seealso{
 \code{\link[=epidata_meta]{epidata_meta()}}, \code{\link[=epirange]{epirange()}}
 }

--- a/man/covidcast_epidata.Rd
+++ b/man/covidcast_epidata.Rd
@@ -26,21 +26,6 @@ The \code{covidcast_epidata()} function fetches a list of all signals, and retur
 an object containing fields for every signal:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{epidata <- covidcast_epidata()
-#> Waiting 4s for retry backoff =======>-----------------------
-#> Waiting 4s for retry backoff =========>---------------------
-#> Waiting 4s for retry backoff ==========>--------------------
-#> Waiting 4s for retry backoff ============>------------------
-#> Waiting 4s for retry backoff =============>-----------------
-#> Waiting 4s for retry backoff ===============>---------------
-#> Waiting 4s for retry backoff =================>-------------
-#> Waiting 4s for retry backoff ==================>------------
-#> Waiting 4s for retry backoff ====================>----------
-#> Waiting 4s for retry backoff =====================>---------
-#> Waiting 4s for retry backoff =======================>-------
-#> Waiting 4s for retry backoff =========================>-----
-#> Waiting 4s for retry backoff ==========================>----
-#> Waiting 4s for retry backoff ============================>--
-#> Waiting 4s for retry backoff ==============================>
 epidata$signals
 #> # A tibble: 520 x 3
 #>    source        signal                        short_description                

--- a/tests/testthat/_snaps/epidatacall.md
+++ b/tests/testthat/_snaps/epidatacall.md
@@ -124,3 +124,68 @@
       ]
     }
 
+# fetch classic works
+
+    {
+      "type": "list",
+      "attributes": {},
+      "value": [
+        {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["epiweek", "forecast"]
+            }
+          },
+          "value": [
+            {
+              "type": "integer",
+              "attributes": {},
+              "value": [201501]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["_version", "baselines", "data"]
+                }
+              },
+              "value": [
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                },
+                {
+                  "type": "list",
+                  "attributes": {
+                    "names": {
+                      "type": "character",
+                      "attributes": {},
+                      "value": ["nat"]
+                    }
+                  },
+                  "value": [
+                    {
+                      "type": "integer",
+                      "attributes": {},
+                      "value": [2]
+                    }
+                  ]
+                },
+                {
+                  "type": "list",
+                  "attributes": {},
+                  "value": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -192,7 +192,7 @@ test_that("epidata* and epidata_meta work as expected", {
   expect_equal(nrow(res_time_range), 2)
 })
 
-test_that("epidata_snapshot validations", {
+test_that("epidata validations and deprecations", {
   # Missing required args
   expect_error(
     epidata_snapshot(source = "nssp", signals = "sig1"),
@@ -209,6 +209,29 @@ test_that("epidata_snapshot validations", {
       report_time = "<2024-01-01"
     ),
     class = "epidatr__epidata__version_and_as_of_exclusive"
+  )
+
+  # Deprecation warnings in epidata
+  expect_warning(
+    epidata(
+      source = "nssp",
+      signals = "sig1",
+      geo_type = "state",
+      version = "2024-01-01",
+      fetch_args = fetch_args_list(dry_run = TRUE)
+    ),
+    regexp = "Use `report_time` instead"
+  )
+
+  expect_warning(
+    epidata(
+      source = "nssp",
+      signals = "sig1",
+      geo_type = "state",
+      time_values = "2024-01-01",
+      fetch_args = fetch_args_list(dry_run = TRUE)
+    ),
+    regexp = "Use `reference_time` instead"
   )
 })
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -217,7 +217,7 @@ test_that("epidata validations and deprecations", {
       source = "nssp",
       signals = "sig1",
       geo_type = "state",
-      version = "2024-01-01",
+      issues = "2024-01-01",
       fetch_args = fetch_args_list(dry_run = TRUE)
     ),
     regexp = "Use `report_time` instead"

--- a/tests/testthat/test-epidatacall.R
+++ b/tests/testthat/test-epidatacall.R
@@ -125,6 +125,7 @@ test_that("fetch classic works", {
     fetch_out <- pub_delphi(system = "ec", epiweek = 201501)
   )
   expect_true(inherits(fetch_out, "list"))
+  expect_snapshot_value(fetch_out, style = "json2", cran = TRUE)
 })
 
 test_that("create_epidata_call basic behavior", {

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -109,36 +109,25 @@ test_that("parse_value can handle NA/NULL values in an int field", {
   )
 })
 
-test_that("parse_api_date accepts str and int input", {
+test_that("parse_api_date", {
+  # accepts str
   expect_identical(parse_api_date("20200101"), as.Date("2020-01-01"))
-  expect_identical(parse_api_date(20200101), as.Date("2020-01-01"))
-})
-
-test_that("parse_api_date accepts YYYYMMDD and YYYY-MM-DD", {
+  # accepts YYYYMMDD and YYYY-MM-DD (int and str)
   expect_identical(parse_api_date(20200101), as.Date("2020-01-01"))
   expect_identical(parse_api_date("2020-01-01"), as.Date("2020-01-01"))
-})
-
-test_that("parse_api_date handles missing values appropriately", {
+  # handles missing values appropriately
   expect_identical(parse_api_date(NA), as.Date(NA))
-})
-
-test_that("parse_api_date works on mixed formats", {
-  vals <- c("20210101", "2021-01-02", "01032021", NA)
-  expected <- as.Date(c("2021-01-01", "2021-01-02", "2021-01-03", NA))
-  expect_equal(parse_api_date(vals), expected)
-})
-
-test_that("parse_api_date handles all NAs", {
-  vals <- c(NA, NA)
-  expected <- as.Date(c(NA, NA))
-  expect_equal(parse_api_date(vals), expected)
-})
-
-test_that("parse_api_date handles invalid dates gracefully", {
-  vals <- c("invalid", "20210101")
-  expected <- as.Date(c(NA, "2021-01-01"))
-  expect_equal(parse_api_date(vals), expected)
+  expect_equal(parse_api_date(c(NA, NA)), as.Date(c(NA, NA)))
+  # parse_api_date works on mixed formats
+  expect_equal(
+    parse_api_date(c("20210101", "2021-01-02", "01032021", NA)),
+    as.Date(c("2021-01-01", "2021-01-02", "2021-01-03", NA))
+  )
+  # handles invalid dates gracefully
+  expect_equal(
+    parse_api_date(c("invalid", "20210101")),
+    as.Date(c(NA, "2021-01-01"))
+  )
 })
 
 test_that("parse_api_timestamp_to_datetime works on timestamps", {
@@ -149,15 +138,13 @@ test_that("parse_api_timestamp_to_datetime works on timestamps", {
   expect_identical(parse_api_timestamp_to_datetime(as.character(val)), expected)
 
   # Check vectorization
-  vals <- c(1000000000, 1592707979)
-  expected <- as.POSIXct(c(1000000000, 1592707979), origin = "1970-01-01")
-  expect_equal(parse_api_timestamp_to_datetime(vals), expected)
-})
-
-test_that("parse_api_timestamp_to_datetime handles missing values appropriately", {
+  expect_equal(
+    parse_api_timestamp_to_datetime(c(1000000000, 1592707979)),
+    as.POSIXct(c(1000000000, 1592707979), origin = "1970-01-01")
+  )
+  # Missing values
   expect_identical(parse_api_timestamp_to_datetime(NA), as.POSIXct(NA))
 })
-
 
 test_that("parse_api_week returns the expected day of the week", {
   expect_identical(parse_api_week(202005) %>% weekdays(), "Sunday")
@@ -168,9 +155,7 @@ test_that("parse_api_week returns the expected day of the week", {
 test_that("date_to_epiweek accepts str and int input", {
   expect_identical(date_to_epiweek("20200101"), 202001)
   expect_identical(date_to_epiweek(20200101), 202001)
-})
-
-test_that("date_to_epiweek accepts single and double-digit weeks", {
+  # Single and double-digit weeks
   expect_identical(date_to_epiweek(20201101), 202045)
   expect_identical(date_to_epiweek(20200109), 202002)
 })

--- a/vignettes/v5-api-demo.Rmd
+++ b/vignettes/v5-api-demo.Rmd
@@ -25,7 +25,10 @@ Let's check the source-specific metadata for `nssp`.
 
 ```{r meta-example}
 meta_nssp <- epidata_meta(source = "nssp")
-head(meta_nssp)
+meta_nssp$nssp$signals
+meta_nssp$nssp$geo_types
+meta_nssp$nssp$version_range
+meta_nssp$nssp$time_value_range
 ```
 
 ### Basic Queries
@@ -85,7 +88,11 @@ Here are some examples for NHSN (hospitalizations), POPHIVE, and NWSS (wastewate
 
 ```{r other-sources-examples}
 # NHSN: Hospital Admissions
-epidata_meta(source = "nhsn")
+meta_nhsn <- epidata_meta(source = "nhsn")
+meta_nhsn$nhsn$signals
+meta_nhsn$nhsn$geo_types
+meta_nhsn$nhsn$version_range
+meta_nhsn$nhsn$time_value_range
 nhsn_data <- epidata_snapshot(
   source = "nhsn",
   signal = "confirmed_admissions_flu_ew",
@@ -94,7 +101,11 @@ nhsn_data <- epidata_snapshot(
 head(nhsn_data)
 
 # POPHIVE
-epidata_meta(source = "pophive")
+meta_pophive <- epidata_meta(source = "pophive")
+meta_pophive$pophive$signals
+meta_pophive$pophive$geo_types
+meta_pophive$pophive$version_range
+meta_pophive$pophive$time_value_range
 pophive_data <- epidata_snapshot(
   source = "pophive",
   signal = "covid_pct_ed",
@@ -103,7 +114,11 @@ pophive_data <- epidata_snapshot(
 head(pophive_data)
 
 # NWSS: Wastewater Surveillance
-epidata_meta(source = "nwss")
+meta_nwss <- epidata_meta(source = "nwss")
+meta_nwss$nwss$signals
+meta_nwss$nwss$geo_types
+meta_nwss$nwss$version_range
+meta_nwss$nwss$time_value_range
 nwss_data <- epidata_snapshot(
   source = "nwss",
   signal = "covid_avg_conc",

--- a/vignettes/v5-api-demo.Rmd
+++ b/vignettes/v5-api-demo.Rmd
@@ -74,8 +74,7 @@ If you want to track how data for a specific time period was revised over time, 
 archive_data <- epidata_archive(
   source = "nssp",
   signal = "pct_ed_visits_influenza",
-  geo_type = "state",
-  time_values = epirange(20230101, 20230114)
+  geo_type = "state"
 )
 head(archive_data)
 ```


### PR DESCRIPTION
### Checklist

Please:

- [ ] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [ ] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [ ] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### This PR replaces #342:
* Incorporates the latest updates on dev
* Keeps `version` and `time_values` as deprecated parameters and adds badges.
* Removes `time_values` filtering in vignettes/v5-api-demo.Rmd to avoid check errors (this won't be an issue when cmu-delphi/cast-api/pull/62 is released). 

