### PR TITLE
fix: rename archive version_query param to report_time_query to match API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epidatr
 Title: Client for Delphi's 'Epidata' API
-Version: 1.2.4
+Version: 1.3.1
 Authors@R: c(
     person("Logan", "Brooks", , "lcbrooks@andrew.cmu.edu", role = "aut"),
     person("Dmitry", "Shemetov", , "dshemeto@andrew.cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 
 ## Patches
 
+- `epidata_archive(report_time = ...)` now sends the `report_time_query` API parameter; the server renamed it from `version_query`, which it now rejects.
 - `last_update` in `pub_covidcast_meta` is now returned as a `POSIXct` object instead of an integer.
 - Improved efficiency of date parsing for API responses.
 - Migrate HTTP requests from `httr` to `httr2`.

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1233,7 +1233,7 @@ epidata_meta <- function(source = NULL, fetch_args = fetch_args_list()) {
 #' @param report_time Date, string, or [`epirange()`]. A query on the
 #'   `report_time` column for the archive endpoint. Supports exact dates (e.g.,
 #'   `"2025-10-16"`), operators (e.g., `"<2025-10-16"`), or an [`epirange()`].
-#'   Internally maps to the `version_query` API parameter.
+#'   Internally maps to the `report_time_query` API parameter.
 #' @param issues `r lifecycle::badge("deprecated")` Use `report_time` instead.
 #' @param time_values `r lifecycle::badge("deprecated")` Use `reference_time` instead.
 #' @param ... Named filters on extra key columns beyond `geo_value`, such as
@@ -1410,7 +1410,7 @@ epidata_archive <- function(
       signal = paste(signals, collapse = ","),
       geo_type = geo_type,
       fill_method = fill_method,
-      version_query = version_query,
+      report_time_query = version_query,
       extra_keys = extra_keys
     ),
     meta = list(

--- a/man/cast_api_queries.Rd
+++ b/man/cast_api_queries.Rd
@@ -96,7 +96,7 @@ to \code{fetch()}. See \code{fetch_args_list()} for details.}
 \item{report_time}{Date, string, or \code{\link[=epirange]{epirange()}}. A query on the
 \code{report_time} column for the archive endpoint. Supports exact dates (e.g.,
 \code{"2025-10-16"}), operators (e.g., \code{"<2025-10-16"}), or an \code{\link[=epirange]{epirange()}}.
-Internally maps to the \code{version_query} API parameter.}
+Internally maps to the \code{report_time_query} API parameter.}
 
 \item{issues}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{report_time} instead.}
 }

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -172,7 +172,7 @@ test_that("epidata* and epidata_meta work as expected", {
     fetch_args = fetch_args_list(dry_run = TRUE)
   )
   expect_match(call_wildcard$request$url, "archive/")
-  expect_no_match(call_wildcard$request$url, "version_query=")
+  expect_no_match(call_wildcard$request$url, "report_time_query=")
 
   # Test snapshot_date = "*" mapping in epidata routes to archive
   call_as_of_wildcard <- epidata(


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

Bugfix over outdated API parameter.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
