### PR TITLE
test: cover cast versioning args (snapshot_date, report_time) in live tests

### DIFF
--- a/tests/testthat/test-live.R
+++ b/tests/testthat/test-live.R
@@ -361,6 +361,40 @@ cast_queries <- tibble::tribble(
   "nwss", "covid_avg_conc", "sewershed",
 )
 
+test_that("cast versioning args reach the server (snapshot_date, report_time_query)", {
+  skip_unless_live()
+  snap <- epidata_snapshot(
+    source = "nssp", signals = "pct_ed_visits_influenza", geo_type = "state",
+    geo_values = "pa", snapshot_date = "2025-01-01"
+  )
+  expect_gt(nrow(snap), 0)
+  expect_true(all(snap$report_time <= as.Date("2025-01-01")))
+
+  arch_lt <- epidata_archive(
+    source = "nssp", signals = "pct_ed_visits_influenza", geo_type = "state",
+    geo_values = "pa", report_time = "<2025-06-01"
+  )
+  expect_gt(nrow(arch_lt), 0)
+  expect_true(all(arch_lt$report_time < as.Date("2025-06-01")))
+
+  one_day <- max(arch_lt$report_time)
+  arch_eq <- epidata_archive(
+    source = "nssp", signals = "pct_ed_visits_influenza", geo_type = "state",
+    geo_values = "pa", report_time = one_day
+  )
+  expect_gt(nrow(arch_eq), 0)
+  expect_true(all(arch_eq$report_time == one_day))
+
+  # epirange: upper bound goes server-side, lower bound is filtered locally
+  arch_range <- epidata_archive(
+    source = "nssp", signals = "pct_ed_visits_influenza", geo_type = "state",
+    geo_values = "pa", report_time = epirange("2025-01-01", "2025-06-01")
+  )
+  expect_gt(nrow(arch_range), 0)
+  expect_true(all(arch_range$report_time >= as.Date("2025-01-01")))
+  expect_true(all(arch_range$report_time <= as.Date("2025-06-01")))
+})
+
 test_that("epidata_meta returns signals + geo_types for each cast source", {
   skip_unless_live()
   for (src in unique(cast_queries$source)) {


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

Live tests using the versioning args (against cast-api to help catch API-client desync).
