### PR TITLE
Add ci_lower and ci_upper fields to endpoint schemas and optimize CSV parsing

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1331,6 +1331,8 @@ epidata_snapshot <- function(
       create_epidata_field_info("fill_method", "text"),
       create_epidata_field_info("reference_time", "date"),
       create_epidata_field_info("value", "float"),
+      create_epidata_field_info("ci_lower", "float"), # nickel_beta, va_respiratory, sleepcycle
+      create_epidata_field_info("ci_upper", "float"), # nickel_beta, va_respiratory, sleepcycle
       # source-specific extra columns
       create_epidata_field_info("age_group", "text"), # pophive
       create_epidata_field_info("nwss_source", "text"), # nwss
@@ -1421,6 +1423,8 @@ epidata_archive <- function(
       create_epidata_field_info("fill_method", "text"),
       create_epidata_field_info("reference_time", "date"),
       create_epidata_field_info("value", "float"),
+      create_epidata_field_info("ci_lower", "float"), # nickel_beta, va_respiratory, sleepcycle
+      create_epidata_field_info("ci_upper", "float"), # nickel_beta, va_respiratory, sleepcycle
       # source-specific extra columns
       create_epidata_field_info("age_group", "text"), # pophive
       create_epidata_field_info("nwss_source", "text"), # nwss

--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -343,7 +343,11 @@ request_epidata <- function(epidata_call, fetch_args = fetch_args_list(), simpli
   )
 
   if (epidata_call$response_format == "csv") {
-    return(readr::read_csv(I(httr2::resp_body_string(res)),
+    # Pass raw bytes straight to read_csv() instead of resp_body_string().
+    # This avoids copying the whole response body through readBin/iconv/paste first.
+    # read_csv() routes raw vectors straight to its raw-input parser regardless.
+    # See https://readr.tidyverse.org/reference/datasource.html?q=datasource#null for more information.
+    return(readr::read_csv(httr2::resp_body_raw(res),
       col_types = readr::cols(.default = "c"),
       show_col_types = FALSE
     ))

--- a/R/epidatacall.R
+++ b/R/epidatacall.R
@@ -345,8 +345,9 @@ request_epidata <- function(epidata_call, fetch_args = fetch_args_list(), simpli
   if (epidata_call$response_format == "csv") {
     # Pass raw bytes straight to read_csv() instead of resp_body_string().
     # This avoids copying the whole response body through readBin/iconv/paste first.
-    # read_csv() routes raw vectors straight to its raw-input parser regardless.
-    # See https://readr.tidyverse.org/reference/datasource.html?q=datasource#null for more information.
+    # `datasource()` is internal to readr. It dispatches on
+    # is.raw() before ever considering I()/AsIs, so raw input needs no wrapper
+    # https://github.com/tidyverse/readr/blob/main/R/source.R
     return(readr::read_csv(httr2::resp_body_raw(res),
       col_types = readr::cols(.default = "c"),
       show_col_types = FALSE


### PR DESCRIPTION


### Checklist

Please:

- [X] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [X] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [ ] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

`epidata_snapshot()`/`epidata_archive()` now declare `ci_lower`/`ci_upper` as float, so they parse as numeric instead of character.
CSV parsing now uses `httr2::resp_body_raw()` instead of `resp_body_string() + I()`, skipping redundant buffer copies before `read_csv()`. Same output, but faster parse on large responses.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
