### PR TITLE
fix: save_api_key no longer errors outside a project (#339)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epidatr
 Title: Client for Delphi's 'Epidata' API
-Version: 1.3.4
+Version: 1.3.5
 Authors@R: c(
     person("Logan", "Brooks", , "lcbrooks@andrew.cmu.edu", role = "aut"),
     person("Dmitry", "Shemetov", , "dshemeto@andrew.cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# epidatr 1.3.3
+# epidatr 1.3.5
 
 ## Patches
 
@@ -7,6 +7,7 @@
 - Add a migration guide vignette (`vignette("migration-guide")`) mapping `pub_covidcast` arguments and columns to the new `epidata_snapshot`/`epidata_archive` functions, and update the README and pkgdown reference to lead with the new API.
 - Parse `ci_lower` and `ci_upper` data columns for some signals.
 - Improve CSV parsing performance by reading bytes directly.
+- `save_api_key()` no longer errors when called outside a project; it falls back to the user `.Renviron` (#339).
 
 # epidatr 1.2.4
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -64,7 +64,12 @@ save_api_key <- function() {
   )
   readline()
 
-  if (file.exists(usethis::proj_path(".Renviron"))) {
+  # proj_path() errors when not inside a project; fall back to user scope.
+  project_renviron_exists <- tryCatch(
+    file.exists(usethis::proj_path(".Renviron")),
+    error = function(e) FALSE
+  )
+  if (project_renviron_exists) {
     usethis::edit_r_environ(scope = "project")
 
     cat("\n\n")


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #339
