### PR TITLE
fix: bound vignette API queries with reference_time to avoid CI timeouts

### DIFF
--- a/vignettes/migration-guide.Rmd
+++ b/vignettes/migration-guide.Rmd
@@ -129,6 +129,7 @@ revisions <- epidata_archive(
   signals = "pct_ed_visits_influenza",
   geo_type = "state",
   geo_values = "pa",
+  reference_time = epirange("2024-10-01", "2025-01-01"),
   report_time = "<2025-06-01"
 )
 head(revisions)

--- a/vignettes/v5-api-demo.Rmd
+++ b/vignettes/v5-api-demo.Rmd
@@ -33,13 +33,16 @@ meta_nssp$nssp$time_value_range
 
 ### Basic Queries
 
-We can pull the latest snapshot of a signal.
+We can pull the latest snapshot of a signal. We bound the request with
+`reference_time` to keep the download small; leaving it at the default `"*"`
+fetches the full history.
 
 ```{r snapshot-example}
 nssp_data <- epidata_snapshot(
   source = "nssp",
   signal = "pct_ed_visits_influenza",
-  geo_type = "state"
+  geo_type = "state",
+  reference_time = epirange("2024-10-01", "2025-01-01")
 )
 head(nssp_data)
 ```
@@ -64,20 +67,22 @@ pa_ca_data <- epidata_snapshot(
   signal = "pct_ed_visits_influenza",
   geo_type = "state",
   geo_values = c("PA", "CA"),
-  as_of = "2025-01-01" # fetch data as it was known on this date
+  reference_time = epirange("2024-10-01", "2025-01-01"),
+  snapshot_date = "2025-01-01" # fetch data as it was known on this date
 )
 head(pa_ca_data)
 ```
 
 ### Archive Queries
 
-If you want to track how data for a specific time period was revised over time, you can use `epidata_archive()`.
+If you want to track how data for a specific time period was revised over time, you can use `epidata_archive()`. Archive queries return every revision of each observation, so bounding `reference_time` matters even more here — the full archive of a signal can be enormous.
 
 ```{r archive-example}
 archive_data <- epidata_archive(
   source = "nssp",
   signal = "pct_ed_visits_influenza",
-  geo_type = "state"
+  geo_type = "state",
+  reference_time = epirange("2024-12-01", "2025-01-01")
 )
 head(archive_data)
 ```
@@ -96,7 +101,8 @@ meta_nhsn$nhsn$time_value_range
 nhsn_data <- epidata_snapshot(
   source = "nhsn",
   signal = "confirmed_admissions_flu_ew",
-  geo_type = "state"
+  geo_type = "state",
+  reference_time = epirange("2024-10-01", "2025-01-01")
 )
 head(nhsn_data)
 
@@ -109,7 +115,8 @@ meta_pophive$pophive$time_value_range
 pophive_data <- epidata_snapshot(
   source = "pophive",
   signal = "covid_pct_ed",
-  geo_type = "state"
+  geo_type = "state",
+  reference_time = epirange("2024-10-01", "2025-01-01")
 )
 head(pophive_data)
 
@@ -122,7 +129,8 @@ meta_nwss$nwss$time_value_range
 nwss_data <- epidata_snapshot(
   source = "nwss",
   signal = "covid_avg_conc",
-  geo_type = "sewershed"
+  geo_type = "sewershed",
+  reference_time = epirange("2024-12-01", "2025-01-01")
 )
 head(nwss_data)
 ```


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

Makes the API queries in the vignette smaller so CI doesn't timeout.