### PR TITLE
build: drop vignette-precompile packages from Suggests and usethis from Imports

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^\.jj$
 ^renv$
 ^renv\.lock$
 ^.*\.Rproj$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,23 +47,19 @@ Imports:
     readr,
     rlang,
     tibble,
-    usethis,
+    utils,
     vctrs,
     lifecycle,
     xml2
 Suggests:
-    dplyr,
-    ggplot2,
     knitr,
-    mapproj,
-    maps,
-    ragg,
     rmarkdown,
     testthat (>= 3.1.5),
     withr,
     curl
 VignetteBuilder:
     knitr
+Config/Needs/precompile: dplyr, ggplot2, mapproj, maps, ragg
 Config/Needs/website: cmu-delphi/delphidocs
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,6 +3,7 @@
 ```r
 pak::pkg_install(c('devtools', 'pkgdown', 'styler', 'lintr')) # install dev dependencies
 devtools::install_deps(dependencies = TRUE) # install package dependencies
+pak::local_install_deps(dependencies = "Config/Needs/precompile") # vignette-knitting deps
 devtools::document() # generate package meta data and man files
 devtools::build() # build package
 ```
@@ -24,8 +25,10 @@ calls, so they are knitted ahead of time into the static `vignettes/*.Rmd`
 files that `R CMD build`, CI, and CRAN render without any network access.
 Both files are committed.
 
-To edit a vignette, change its `.Rmd.orig` and re-knit (requires network and
-the current package code installed):
+To edit a vignette, change its `.Rmd.orig` and re-knit. This requires network,
+the current package code installed, and the knitting-only packages listed in
+the `Config/Needs/precompile` field of DESCRIPTION (they are deliberately not
+Suggests, so CI never installs them):
 
 ```bash
 make vignettes                                # all vignettes

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	Rscript -e "install.packages(c('devtools', 'pkgdown', 'webshot', 'textshaping', 'styler', 'lintr'));devtools::install_deps(dependencies = TRUE)"
+	Rscript -e "install.packages(c('pak', 'devtools', 'pkgdown', 'webshot', 'textshaping', 'styler', 'lintr'));devtools::install_deps(dependencies = TRUE);pak::local_install_deps(dependencies = 'Config/Needs/precompile')"
 lint:
 	Rscript -e "devtools::load_all();lintr::lint_package()"
 format:

--- a/R/auth.R
+++ b/R/auth.R
@@ -64,14 +64,19 @@ save_api_key <- function() {
   )
   readline()
 
-  # proj_path() errors when not inside a project; fall back to user scope.
-  project_renviron_exists <- tryCatch(
-    file.exists(usethis::proj_path(".Renviron")),
-    error = function(e) FALSE
-  )
-  if (project_renviron_exists) {
-    usethis::edit_r_environ(scope = "project")
+  # Prefer a project-level .Renviron in the working directory; fall back to
+  # the user-level one R reads at startup (see ?Startup).
+  if (file.exists(".Renviron")) {
+    path <- ".Renviron"
+  } else {
+    path <- path.expand(file.path("~", ".Renviron"))
+    if (!file.exists(path)) {
+      file.create(path)
+    }
+  }
+  utils::file.edit(path)
 
+  if (path == ".Renviron") {
     cat("\n\n")
     cli::cli_inform(
       c(
@@ -79,7 +84,6 @@ save_api_key <- function() {
         file (add it to .gitignore or equivalents)."
       )
     )
-  } else {
-    usethis::edit_r_environ(scope = "user")
   }
+  cli::cli_inform(c("i" = "Restart R for the change to take effect."))
 }

--- a/R/cache.R
+++ b/R/cache.R
@@ -17,7 +17,7 @@ cache_environ$cache_args <- NULL
 #' The typical recommended workflow for using the cache is to set the
 #'   environmental variables `EPIDATR_USE_CACHE=TRUE` and
 #'   `EPIDATR_CACHE_DIRECTORY="/your/directory/here"`in your `.Renviron`, for
-#'   example by calling `usethis::edit_r_environ()`.
+#'   example by calling `file.edit("~/.Renviron")`.
 #' See the parameters below for some more configurables if you're so inclined.
 #'
 #' `set_cache` (re)defines the cache to use in a particular R session. This does

--- a/man/set_cache.Rd
+++ b/man/set_cache.Rd
@@ -49,7 +49,7 @@ variables for a persistent cache.
 The typical recommended workflow for using the cache is to set the
 environmental variables \code{EPIDATR_USE_CACHE=TRUE} and
 \code{EPIDATR_CACHE_DIRECTORY="/your/directory/here"}in your \code{.Renviron}, for
-example by calling \code{usethis::edit_r_environ()}.
+example by calling \code{file.edit("~/.Renviron")}.
 See the parameters below for some more configurables if you're so inclined.
 
 \code{set_cache} (re)defines the cache to use in a particular R session. This does

--- a/vignettes/epidatr.Rmd
+++ b/vignettes/epidatr.Rmd
@@ -6,7 +6,6 @@ output:
 vignette: >
   %\VignetteIndexEntry{Get started with epidatr}
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteDepends{ggplot2}
   \usepackage[utf8]{inputenc}
 ---
 

--- a/vignettes/epidatr.Rmd.orig
+++ b/vignettes/epidatr.Rmd.orig
@@ -6,7 +6,6 @@ output:
 vignette: >
   %\VignetteIndexEntry{Get started with epidatr}
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteDepends{ggplot2}
   \usepackage[utf8]{inputenc}
 ---
 


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current epidatr main reviewers:
      brookslogan, dshemetov, nmdefries, dsweber2.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).

### Change explanations for reviewer

Now that vignettes are precompiled, we can remove their dependencies from Suggests so R CMD check doesn't install them (this mostly speeds up ubuntu (devel) which doesn't get package binaries and has to compile them).
